### PR TITLE
fix(ml): isolate the INT8 regression gate from the tf2onnx-pinned environment

### DIFF
--- a/.github/workflows/train-model.yml
+++ b/.github/workflows/train-model.yml
@@ -60,14 +60,23 @@ jobs:
           unzip -q dataset.zip -d dataset
           ls dataset
 
-      - name: Train, convert, and gate
+      - name: Train, convert, and quantize
         run: |
           python training/train.py \
             --data-dir dataset \
             --output-dir training_output \
             --previous-class-names resources/model/class_names.json \
-            --min-accuracy "${{ inputs.min_accuracy }}" \
             ${{ inputs.fine_tune && '--fine-tune' || '' }}
+
+      # Isolated env: modern onnxruntime can run the QInt8 model, but conflicts
+      # with tf2onnx's pinned onnx — see training/requirements-gate.txt.
+      - name: Regression gate (INT8 on test split)
+        run: |
+          python -m venv gate-env
+          gate-env/bin/pip install -r training/requirements-gate.txt
+          gate-env/bin/python training/gate.py \
+            --output-dir training_output \
+            --min-accuracy "${{ inputs.min_accuracy }}"
 
       - name: Upload training artifacts
         if: always()

--- a/training/gate.py
+++ b/training/gate.py
@@ -1,0 +1,146 @@
+"""INT8 regression gate + report — runs ISOLATED from the training environment.
+
+Why separate: tf2onnx pins an old `onnx`, which caps onnxruntime at a version
+whose CPU provider cannot execute signed-int8 ConvInteger ("Could not find an
+implementation for ConvInteger"). The gate therefore runs in its own minimal
+environment (requirements-gate.txt: modern onnxruntime + numpy) and consumes
+artifacts produced by train.py in --output-dir:
+
+    ability_classifier_int8.onnx   the artifact being judged
+    class_names.json               class order
+    test_data.npz                  exact test tensors (raw 0-255 float32) + labels
+    train_summary.json             training context (keras accuracy, dataset, ...)
+
+Outputs metrics.json + report.md and exits 1 when the gate fails:
+INT8 accuracy < --min-accuracy, or quantization drop > --max-quant-drop.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+
+import numpy as np
+import onnxruntime as ort
+
+BATCH = 64
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="INT8 regression gate")
+    p.add_argument("--output-dir", default="training_output",
+                   help="Directory holding train.py's artifacts; reports go here too")
+    p.add_argument("--min-accuracy", type=float, default=0.97,
+                   help="Gate: minimum INT8 test accuracy")
+    p.add_argument("--max-quant-drop", type=float, default=0.01,
+                   help="Gate: maximum accuracy drop from Keras to INT8")
+    p.add_argument("--no-gate", action="store_true",
+                   help="Report metrics but never fail (experiments)")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    out = args.output_dir
+
+    print(f"onnxruntime {ort.__version__}")
+    with open(os.path.join(out, "class_names.json"), encoding="utf-8") as f:
+        class_names = json.load(f)
+    with open(os.path.join(out, "train_summary.json"), encoding="utf-8") as f:
+        summary = json.load(f)
+
+    data = np.load(os.path.join(out, "test_data.npz"))
+    images, labels = data["images"], data["labels"]
+    print(f"Test tensors: {images.shape[0]} images, {len(class_names)} classes")
+
+    session = ort.InferenceSession(
+        os.path.join(out, "ability_classifier_int8.onnx"),
+        providers=["CPUExecutionProvider"],
+    )
+    input_name = session.get_inputs()[0].name
+    output_name = session.get_outputs()[0].name
+
+    y_pred = []
+    for i in range(0, len(images), BATCH):
+        probs = session.run([output_name], {input_name: images[i:i + BATCH]})[0]
+        y_pred.extend(np.argmax(probs, axis=1).tolist())
+    y_pred = np.array(y_pred)
+    y_true = labels
+
+    int8_acc = float((y_true == y_pred).mean())
+    keras_acc = summary["kerasTestAccuracy"]
+    quant_drop = keras_acc - int8_acc
+    print(f"INT8 test accuracy: {int8_acc:.4f} (drop vs Keras: {quant_drop:+.4f})")
+
+    per_class_recall = {}
+    confusions = Counter()
+    for cls_idx, name in enumerate(class_names):
+        mask = y_true == cls_idx
+        if mask.sum() == 0:
+            continue
+        per_class_recall[name] = float((y_pred[mask] == cls_idx).mean())
+    for t, p in zip(y_true, y_pred):
+        if t != p:
+            confusions[(class_names[t], class_names[p])] += 1
+
+    gate_passed = int8_acc >= args.min_accuracy and quant_drop <= args.max_quant_drop
+    worst_classes = sorted(per_class_recall.items(), key=lambda kv: kv[1])[:15]
+    top_confusions = confusions.most_common(10)
+
+    metrics = {
+        **summary,
+        "int8TestAccuracy": round(int8_acc, 5),
+        "quantizationDrop": round(float(quant_drop), 5),
+        "gate": {
+            "minAccuracy": args.min_accuracy,
+            "maxQuantDrop": args.max_quant_drop,
+            "passed": gate_passed,
+        },
+        "worstClassRecall": {name: round(r, 4) for name, r in worst_classes},
+        "topConfusions": [
+            {"true": t, "predicted": p, "count": c}
+            for (t, p), c in top_confusions
+        ],
+    }
+    with open(os.path.join(out, "metrics.json"), "w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2)
+
+    added = summary.get("classesAdded", [])
+    removed = summary.get("classesRemoved", [])
+    lines = [
+        "## Model retrain report",
+        "",
+        f"- Dataset: v{summary.get('datasetVersion', '?')} ({summary.get('datasetCreatedAt', 'unknown date')})",
+        f"- Classes: **{summary['numClasses']}** ({summary['trainImages']} training images, seed {summary['seed']})",
+        f"- Keras test accuracy: **{keras_acc:.2%}**",
+        f"- INT8 ONNX test accuracy: **{int8_acc:.2%}** (quantization drop {quant_drop:+.2%})",
+        f"- Gate (≥{args.min_accuracy:.0%}, drop ≤{args.max_quant_drop:.0%}): "
+        + ("**PASSED** ✅" if gate_passed else "**FAILED** ❌"),
+        f"- Fine-tuned top block: {'yes' if summary.get('fineTuned') else 'no'}",
+        f"- INT8 size: {summary.get('int8SizeMb', '?')} MB",
+    ]
+    if added:
+        lines += ["", f"### New classes ({len(added)})", ""]
+        lines += [f"- `{name}`" for name in added]
+    if removed:
+        lines += ["", f"### Removed classes ({len(removed)})", ""]
+        lines += [f"- `{name}`" for name in removed]
+    lines += ["", "### Worst per-class recall (test split)", ""]
+    lines += [f"- `{name}`: {r:.0%}" for name, r in worst_classes]
+    if top_confusions:
+        lines += ["", "### Top confusions", ""]
+        lines += [f"- `{t}` → `{p}` ({c}×)" for (t, p), c in top_confusions]
+
+    with open(os.path.join(out, "report.md"), "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print("\n" + "\n".join(lines))
+
+    if not gate_passed and not args.no_gate:
+        print("\nGATE FAILED — model artifacts were produced but must not ship.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/training/requirements-gate.txt
+++ b/training/requirements-gate.txt
@@ -1,0 +1,6 @@
+# Isolated environment for training/gate.py ONLY. Modern onnxruntime is needed
+# to execute the QInt8-quantized model (signed-int8 ConvInteger has no CPU
+# implementation in the old ORT that the training env is stuck on via tf2onnx).
+# 1.28 verified against the shipped app model; matches the app's ORT line.
+onnxruntime==1.28.0
+numpy

--- a/training/requirements.txt
+++ b/training/requirements.txt
@@ -1,5 +1,10 @@
 # Pinned combo known to work together (tf2onnx lags TensorFlow releases).
 # Python 3.11 required (TF 2.15 does not support 3.12).
+# NOTE: onnxruntime here is ONLY for quantize_dynamic. This old version cannot
+# RUN the resulting QInt8 model (no signed-int8 ConvInteger on CPU) — the
+# regression gate runs separately with requirements-gate.txt. Newer ORT cannot
+# be used here: tf2onnx 1.16 pins an `onnx` version that conflicts with it
+# (verified ResolutionImpossible).
 tensorflow==2.15.1
 tf2onnx==1.16.1
 onnxruntime==1.18.1

--- a/training/train.py
+++ b/training/train.py
@@ -35,7 +35,6 @@ import os
 import random
 import subprocess
 import sys
-from collections import Counter
 from datetime import datetime, timezone
 
 import numpy as np
@@ -56,12 +55,6 @@ def parse_args():
                    help="After head training, unfreeze the top MobileNetV2 block "
                         "and continue at a low learning rate")
     p.add_argument("--fine-tune-epochs", type=int, default=8)
-    p.add_argument("--min-accuracy", type=float, default=0.97,
-                   help="Gate: minimum INT8 test accuracy")
-    p.add_argument("--max-quant-drop", type=float, default=0.01,
-                   help="Gate: maximum accuracy drop from Keras to INT8")
-    p.add_argument("--no-gate", action="store_true",
-                   help="Report metrics but never fail the gate (experiments)")
     p.add_argument("--previous-class-names", default=None,
                    help="Path to the currently shipped class_names.json, for the "
                         "added/removed class diff in the report")
@@ -170,37 +163,24 @@ def build_inference_model(tf, base_model, trained_model, num_classes):
     return inference_model
 
 
-def evaluate_onnx(onnx_path, test_ds, class_names):
-    """Run the shipped INT8 artifact over the test split — the honest gate."""
-    import onnxruntime as ort
+def export_test_tensors(test_ds, output_dir):
+    """Dump the exact test tensors (raw 0-255 float32) for the isolated gate step.
 
-    session = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
-    input_name = session.get_inputs()[0].name
-    output_name = session.get_outputs()[0].name
-
-    y_true, y_pred = [], []
+    The gate (training/gate.py) runs in a separate environment with a modern
+    onnxruntime — tf2onnx pins an old `onnx` that conflicts with the ORT
+    versions able to execute signed-int8 ConvInteger. Handing over tensors
+    instead of re-loading images guarantees both accuracy measurements see
+    byte-identical inputs.
+    """
+    images, labels = [], []
     for batch_images, batch_labels in test_ds:
-        arr = batch_images.numpy().astype(np.float32)  # raw 0-255, as in the app
-        out = session.run([output_name], {input_name: arr})[0]
-        y_pred.extend(np.argmax(out, axis=1).tolist())
-        y_true.extend(batch_labels.numpy().tolist())
-
-    y_true = np.array(y_true)
-    y_pred = np.array(y_pred)
-    accuracy = float((y_true == y_pred).mean())
-
-    per_class_recall = {}
-    confusions = Counter()
-    for cls_idx, name in enumerate(class_names):
-        mask = y_true == cls_idx
-        if mask.sum() == 0:
-            continue
-        per_class_recall[name] = float((y_pred[mask] == cls_idx).mean())
-    for t, p in zip(y_true, y_pred):
-        if t != p:
-            confusions[(class_names[t], class_names[p])] += 1
-
-    return accuracy, per_class_recall, confusions
+        images.append(batch_images.numpy().astype(np.float32))
+        labels.append(batch_labels.numpy())
+    np.savez_compressed(
+        os.path.join(output_dir, "test_data.npz"),
+        images=np.concatenate(images),
+        labels=np.concatenate(labels),
+    )
 
 
 def main():
@@ -307,18 +287,9 @@ def main():
     int8_mb = os.path.getsize(int8_path) / (1024 * 1024)
     print(f"INT8 model: {int8_mb:.1f} MB")
 
-    print("\n=== Regression gate: INT8 ONNX on test split ===")
-    int8_acc, per_class_recall, confusions = evaluate_onnx(
-        int8_path, test_ds, class_names
-    )
-    quant_drop = keras_acc - int8_acc
-    print(f"INT8 test accuracy: {int8_acc:.4f} (drop vs Keras: {quant_drop:+.4f})")
-
-    gate_passed = int8_acc >= args.min_accuracy and quant_drop <= args.max_quant_drop
-
-    # ── Reports ───────────────────────────────────────────────────────────────
-    worst_classes = sorted(per_class_recall.items(), key=lambda kv: kv[1])[:15]
-    top_confusions = confusions.most_common(10)
+    # ── Hand-off to the isolated gate step (training/gate.py) ─────────────────
+    print("\n=== Exporting test tensors + training summary for the gate ===")
+    export_test_tensors(test_ds, args.output_dir)
 
     added, removed = [], []
     if args.previous_class_names and os.path.isfile(args.previous_class_names):
@@ -328,7 +299,7 @@ def main():
         added = sorted(current - previous)
         removed = sorted(previous - current)
 
-    metrics = {
+    summary = {
         "trainedAt": datetime.now(timezone.utc).isoformat(),
         "datasetVersion": manifest.get("version"),
         "datasetCreatedAt": manifest.get("createdAt"),
@@ -338,57 +309,15 @@ def main():
         "fineTuned": bool(args.fine_tune),
         "epochsRun": len(history.history.get("accuracy", [])),
         "kerasTestAccuracy": round(float(keras_acc), 5),
-        "int8TestAccuracy": round(int8_acc, 5),
-        "quantizationDrop": round(float(quant_drop), 5),
-        "gate": {
-            "minAccuracy": args.min_accuracy,
-            "maxQuantDrop": args.max_quant_drop,
-            "passed": gate_passed,
-        },
         "classesAdded": added,
         "classesRemoved": removed,
-        "worstClassRecall": {name: round(r, 4) for name, r in worst_classes},
-        "topConfusions": [
-            {"true": t, "predicted": p, "count": c}
-            for (t, p), c in top_confusions
-        ],
         "int8SizeMb": round(int8_mb, 2),
     }
-    with open(os.path.join(args.output_dir, "metrics.json"), "w", encoding="utf-8") as f:
-        json.dump(metrics, f, indent=2)
+    with open(os.path.join(args.output_dir, "train_summary.json"), "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
 
-    lines = [
-        "## Model retrain report",
-        "",
-        f"- Dataset: v{manifest.get('version', '?')} ({manifest.get('createdAt', 'unknown date')})",
-        f"- Classes: **{num_classes}** ({int(train_counts.sum())} training images, seed {args.seed})",
-        f"- Keras test accuracy: **{keras_acc:.2%}**",
-        f"- INT8 ONNX test accuracy: **{int8_acc:.2%}** (quantization drop {quant_drop:+.2%})",
-        f"- Gate (≥{args.min_accuracy:.0%}, drop ≤{args.max_quant_drop:.0%}): "
-        + ("**PASSED** ✅" if gate_passed else "**FAILED** ❌"),
-        f"- Fine-tuned top block: {'yes' if args.fine_tune else 'no'}",
-        f"- INT8 size: {int8_mb:.1f} MB",
-    ]
-    if added:
-        lines += ["", f"### New classes ({len(added)})", ""]
-        lines += [f"- `{name}`" for name in added]
-    if removed:
-        lines += ["", f"### Removed classes ({len(removed)})", ""]
-        lines += [f"- `{name}`" for name in removed]
-    lines += ["", "### Worst per-class recall (test split)", ""]
-    lines += [f"- `{name}`: {r:.0%}" for name, r in worst_classes]
-    if top_confusions:
-        lines += ["", "### Top confusions", ""]
-        lines += [f"- `{t}` → `{p}` ({c}×)" for (t, p), c in top_confusions]
-
-    with open(os.path.join(args.output_dir, "report.md"), "w", encoding="utf-8") as f:
-        f.write("\n".join(lines) + "\n")
-
-    print("\n" + "\n".join(lines))
-
-    if not gate_passed and not args.no_gate:
-        print("\nGATE FAILED — model artifacts were produced but must not ship.")
-        sys.exit(1)
+    print("Training complete. Run training/gate.py (isolated env) for the "
+          "INT8 regression gate and report.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
First retrain run failed with 'Could not find an implementation for ConvInteger' - old ORT (forced by tf2onnx's onnx pin) cannot execute QInt8 models. The gate now runs in its own minimal venv with ORT 1.28 (verified locally against the shipped app model), consuming exact test tensors exported by train.py. See training/requirements-gate.txt rationale comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)