### PR TITLE
fix(ml): bump onnxconverter-common to 1.16.0 - 1.14.0 protobuf pin breaks the training env resolve

### DIFF
--- a/training/requirements.txt
+++ b/training/requirements.txt
@@ -6,6 +6,8 @@
 tensorflow==2.15.1
 tf2onnx==1.16.1
 onnxruntime==1.18.1
-onnxconverter-common==1.14.0
+# 1.14.0 hard-pins protobuf==3.20.2, which conflicts with TF's >=3.20.3;
+# 1.16.0 declares protobuf unpinned and resolves cleanly (verified locally)
+onnxconverter-common==1.16.0
 numpy<2
 protobuf~=3.20


### PR DESCRIPTION
1.14.0 hard-pins protobuf==3.20.2, conflicting with TF 2.15's >=3.20.3. 1.16.0 declares protobuf unpinned and is the version verified locally with the working fp16 conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)