### PR TITLE
fix: scan accuracy regressions - capture self-contamination + resize-kernel skew

### DIFF
--- a/src/core/ml/preprocessing.ts
+++ b/src/core/ml/preprocessing.ts
@@ -21,7 +21,12 @@ export async function preprocessSlot(
 ): Promise<Buffer> {
   return sharp(screenshotBuffer)
     .extract({ left: slot.x, top: slot.y, width: slot.width, height: slot.height })
-    .resize(MODEL_INPUT_SIZE, MODEL_INPUT_SIZE)
+    // kernel MUST be 'linear' (bilinear): the training pipeline resizes with TF's
+    // bilinear interpolation, and sharp's default lanczos3 produces sharpening
+    // artifacts the model never saw — verified on a real capture to drop
+    // borderline classes from ~0.7-0.9 confidence to ~0.26-0.72 (below the 0.9
+    // threshold → rendered as Unknown). Train/serve resize kernels must match.
+    .resize(MODEL_INPUT_SIZE, MODEL_INPUT_SIZE, { kernel: 'linear' })
     .removeAlpha()
     .raw()
     .toBuffer()

--- a/src/renderer/overlay/src/App.tsx
+++ b/src/renderer/overlay/src/App.tsx
@@ -139,7 +139,7 @@ function App(): React.ReactElement {
     scanState === 'error' ? ('error' as const) : ('info' as const)
 
   return (
-    <div className="overlay-root">
+    <div className={`overlay-root${scanState === 'scanning' ? ' capture-mode' : ''}`}>
       {/* Hotspot Layer (abilities + hero models + tooltip) */}
       {overlayData?.scanData && (
         <HotspotLayer

--- a/src/renderer/overlay/src/globals.css
+++ b/src/renderer/overlay/src/globals.css
@@ -314,6 +314,22 @@ body {
   box-shadow: none !important;
 }
 
+/* Capture mode (active while a scan is in flight): every overlay decoration must
+   vanish from the screen, or the captured screenshot contains our own borders
+   inside the icon crops and the ML confidence collapses. The status toast stays
+   visible (bottom-right, never overlaps slots). */
+.capture-mode .ability-hotspot,
+.capture-mode .hero-model-hotspot {
+  border: none !important;
+  animation: none !important;
+  box-shadow: none !important;
+}
+
+.capture-mode .dynamic-btn,
+.capture-mode .top-right-column {
+  visibility: hidden !important;
+}
+
 /* ML could not identify this slot */
 .unknown-slot {
   border: 2px dashed rgba(230, 170, 40, 0.85);

--- a/src/renderer/overlay/src/hooks/use-overlay-data.ts
+++ b/src/renderer/overlay/src/hooks/use-overlay-data.ts
@@ -124,9 +124,18 @@ export function useOverlayData(): OverlayState & {
       setScanState('error')
       setScanError(i18n.t('status.timeoutMessage'))
     }, SCAN_TIMEOUT_MS)
-    window.electronApi.send('ml:scan', {
-      heroOrder: selectedSpotHeroOrder ?? 0,
-      isInitialScan,
+    // CRITICAL: the scanning state hides all overlay decorations (capture-mode CSS).
+    // Wait two frames so the compositor has actually painted their removal before
+    // main captures the screen — otherwise shimmer borders end up INSIDE the
+    // cropped icons and borderline classes drop below the confidence threshold
+    // (this made previously-recognized top-pick abilities scan as Unknown).
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.electronApi.send('ml:scan', {
+          heroOrder: selectedSpotHeroOrder ?? 0,
+          isInitialScan,
+        })
+      })
     })
   }
 

--- a/tests/unit/core/ml/preprocessing.test.ts
+++ b/tests/unit/core/ml/preprocessing.test.ts
@@ -79,7 +79,9 @@ describe('preprocessing', () => {
         width: 60,
         height: 70,
       })
-      expect(mockSharpChain.resize).toHaveBeenCalledWith(96, 96)
+      // bilinear kernel matches the training pipeline's TF resize — lanczos
+      // sharpening artifacts drop borderline classes below the 0.9 threshold
+      expect(mockSharpChain.resize).toHaveBeenCalledWith(96, 96, { kernel: 'linear' })
       expect(mockSharpChain.removeAlpha).toHaveBeenCalled()
       expect(mockSharpChain.raw).toHaveBeenCalled()
       expect(result).toBe(expectedOutput)

--- a/tests/unit/renderer/overlay/use-overlay-data.test.ts
+++ b/tests/unit/renderer/overlay/use-overlay-data.test.ts
@@ -310,7 +310,12 @@ describe('useOverlayData', () => {
   })
 
   describe('triggerScan', () => {
-    it('sends ml:scan IPC and sets scanState to scanning', () => {
+    // The ml:scan send is deferred by two animation frames so the capture-mode
+    // CSS (hiding overlay decorations) is painted before main captures the screen
+    const flushAnimationFrames = () =>
+      act(() => new Promise<void>((resolve) => setTimeout(resolve, 100)))
+
+    it('sets scanState to scanning immediately and sends ml:scan after paint', async () => {
       const { result } = renderHook(() => useOverlayData())
 
       // Must have overlayData first
@@ -319,13 +324,14 @@ describe('useOverlayData', () => {
       act(() => result.current.triggerScan(true))
 
       expect(result.current.scanState).toBe('scanning')
+      await flushAnimationFrames()
       expect(mockSend).toHaveBeenCalledWith('ml:scan', {
         heroOrder: 0,
         isInitialScan: true,
       })
     })
 
-    it('uses selectedSpotHeroOrder in scan request', () => {
+    it('uses selectedSpotHeroOrder in scan request', async () => {
       const { result } = renderHook(() => useOverlayData())
 
       act(() => emit('overlay:data', makeOverlayPayload()))
@@ -334,6 +340,7 @@ describe('useOverlayData', () => {
       )
 
       act(() => result.current.triggerScan(false))
+      await flushAnimationFrames()
 
       expect(mockSend).toHaveBeenCalledWith('ml:scan', {
         heroOrder: 4,


### PR DESCRIPTION
Two verified root causes behind previously-recognized abilities scanning as Unknown:

1. **Overlay self-contamination**: re-scans captured our own shimmer borders inside icon crops (simulated border drops nova 0.85 -> 0.25). Fixed via capture-mode CSS + two-frame paint deferral.
2. **Train/serve resize-kernel skew** (found via a real feedback snapshot after the first fix proved insufficient): training resizes bilinear, sharp inference defaulted to lanczos3 - same live crop scores 0.264 (lanczos) vs 0.710 (bilinear) for crystal_nova, 0.718 vs 0.919 for dark_lord. Kernel aligned to 'linear'.

With this PR dark_lord recognizes again; crystal_nova rises to ~0.71 (still sub-threshold) - it needs the margin boost from a fine-tuned retrain, dispatched separately and validated against the same snapshot before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)