### PR TITLE
fix(scraper): prune stale ability rows + repair Liquipedia enrichment matching

### DIFF
--- a/src/core/database/repositories/ability-repository.ts
+++ b/src/core/database/repositories/ability-repository.ts
@@ -1,14 +1,19 @@
-import { eq, inArray, sql } from 'drizzle-orm'
+import { and, eq, inArray, notInArray, sql } from 'drizzle-orm'
 import type { SQLJsDatabase } from 'drizzle-orm/sql-js'
-import { abilities } from '../schema'
+import { abilities, heroes } from '../schema'
 import type { AbilityDetail } from '@shared/types'
 
 // @DEV-GUIDE: Ability CRUD repository. Key methods:
 // - getDetails(names[]): Batch lookup by internal name, returns Map<name, AbilityDetail>.
 //   This is the hot path during scan processing (Phase 3).
 // - upsertAbilities: Batch insert from scraper with ON CONFLICT UPDATE.
+// - deleteAbilitiesNotIn: Post-scrape prune of abilities that dropped out of Windrun data
+//   (removed/renamed in a patch). Without it, stale rows accumulate and pollute ML
+//   staleness detection. FK cascades clean up dependent synergy/triplet rows.
 // - getNameToIdMap: Returns Map<internalName, abilityId> for synergy/triplet foreign key resolution.
-// - updateAbilityMeta: Applies Liquipedia-sourced ability_order and is_ultimate updates.
+// - applyLiquipediaMeta: Applies Liquipedia-sourced ability_order and is_ultimate updates.
+//   Matches by DISPLAY name scoped to a hero (Liquipedia has no internal names), and only
+//   accepts ultimate candidates (non-Q/W/E hotkey) when Windrun data agrees is_ultimate=1.
 // Used by: scan-processor, scraper orchestrator, Liquipedia enrichment, staleness detector.
 
 export interface AbilityUpsertData {
@@ -22,14 +27,35 @@ export interface AbilityUpsertData {
   isUltimate?: boolean
 }
 
+export interface LiquipediaMetaUpdate {
+  /** Hero display name as stored in Heroes.display_name, e.g. "Drow Ranger" */
+  heroDisplayName: string
+  /** Ability display name as rendered on Liquipedia, e.g. "Shadow Step" */
+  abilityDisplayName: string
+  /** 1-3 for Q/W/E hotkeys; 0 for ultimate candidates */
+  abilityOrder: number
+  /**
+   * True when the Liquipedia hotkey is not Q/W/E (R, F, D, ...). Applied as an
+   * ultimate (order 0) only if the DB row is already is_ultimate per Windrun data —
+   * this filters out sub-abilities (e.g. Spectre's Reality) that also carry hotkeys.
+   */
+  isUltimateCandidate: boolean
+}
+
 export interface AbilityRepository {
   getAll(): AbilityDetail[]
   getDetails(names: string[]): Map<string, AbilityDetail>
   getByHeroId(heroId: number): AbilityDetail[]
   upsertAbilities(batch: AbilityUpsertData[], heroNameToIdMap: Map<string, number>): void
+  /**
+   * Delete abilities whose name is NOT in keepNames (i.e. no longer served by Windrun).
+   * No-op when keepNames is empty (a failed/empty scrape must never wipe the table).
+   * Returns the names of the deleted abilities.
+   */
+  deleteAbilitiesNotIn(keepNames: string[]): string[]
   getNameToIdMap(): Map<string, number>
   getAllNames(): string[]
-  updateAbilityMeta(updates: Array<{ name: string; abilityOrder: number; isUltimate: boolean }>): number
+  applyLiquipediaMeta(updates: LiquipediaMetaUpdate[]): number
 }
 
 function mapRow(row: typeof abilities.$inferSelect): AbilityDetail {
@@ -114,6 +140,19 @@ export function createAbilityRepository(db: SQLJsDatabase): AbilityRepository {
       }
     },
 
+    deleteAbilitiesNotIn(keepNames: string[]): string[] {
+      if (keepNames.length === 0) return []
+      const staleNames = db
+        .select({ name: abilities.name })
+        .from(abilities)
+        .where(notInArray(abilities.name, keepNames))
+        .all()
+        .map((row) => row.name)
+      if (staleNames.length === 0) return []
+      db.delete(abilities).where(inArray(abilities.name, staleNames)).run()
+      return staleNames
+    },
+
     getNameToIdMap(): Map<string, number> {
       const map = new Map<string, number>()
       const rows = db
@@ -134,25 +173,38 @@ export function createAbilityRepository(db: SQLJsDatabase): AbilityRepository {
         .map((row) => row.name)
     },
 
-    updateAbilityMeta(updates: Array<{ name: string; abilityOrder: number; isUltimate: boolean }>): number {
-      let updated = 0
+    applyLiquipediaMeta(updates: LiquipediaMetaUpdate[]): number {
+      let applied = 0
       for (const u of updates) {
-        const existing = db
-          .select({ name: abilities.name })
+        const rows = db
+          .select({ abilityId: abilities.abilityId, isUltimate: abilities.isUltimate })
           .from(abilities)
-          .where(eq(abilities.name, u.name))
+          .innerJoin(heroes, eq(abilities.heroId, heroes.heroId))
+          .where(
+            and(
+              eq(abilities.displayName, u.abilityDisplayName),
+              eq(heroes.displayName, u.heroDisplayName),
+            ),
+          )
           .all()
-        if (existing.length === 0) continue
-        db.update(abilities)
-          .set({
-            abilityOrder: u.abilityOrder,
-            isUltimate: u.isUltimate,
-          })
-          .where(eq(abilities.name, u.name))
-          .run()
-        updated += 1
+        if (rows.length === 0) continue
+        const row = rows[0]
+
+        if (u.isUltimateCandidate) {
+          if (!row.isUltimate) continue
+          db.update(abilities)
+            .set({ abilityOrder: 0, isUltimate: true })
+            .where(eq(abilities.abilityId, row.abilityId))
+            .run()
+        } else {
+          db.update(abilities)
+            .set({ abilityOrder: u.abilityOrder, isUltimate: false })
+            .where(eq(abilities.abilityId, row.abilityId))
+            .run()
+        }
+        applied += 1
       }
-      return updated
+      return applied
     },
   }
 }

--- a/src/core/scraper/liquipedia-scraper.ts
+++ b/src/core/scraper/liquipedia-scraper.ts
@@ -1,7 +1,14 @@
 // @DEV-GUIDE: Dev-mode only Liquipedia HTML parser for ability_order and is_ultimate metadata.
 // Windrun.io provides winrates/synergies but NOT ability ordering within a hero's kit.
 // Liquipedia's MediaWiki API returns rendered HTML with .spellcard-wrapper elements.
-// Each card has a hotkey (Q/W/E/R) mapped to ability_order (1/2/3/0).
+// Spellcard IDs are DISPLAY names ("Shadow_Step"), not internal names — updates carry
+// display names + the hero page they came from; matching against the DB happens in
+// AbilityRepository.applyLiquipediaMeta (per-hero, by display_name).
+// Hotkeys: Q/W/E map to ability_order 1/2/3. ANY other hotkey (R, F, D, ...) marks an
+// ultimate CANDIDATE (order 0) — some ults don't sit on R (Spectre's Haunt is F), and
+// sub-abilities also carry hotkeys, so the repository confirms candidates against
+// Windrun's is_ultimate before applying. Cards without a hotkey (innates, Aghs/Shard)
+// are skipped.
 // Rate limited to 1 request per 31 seconds — a full scrape of ~130 heroes takes ~67 minutes.
 // Only needed when Liquipedia data is stale; not part of the normal user flow.
 
@@ -27,14 +34,13 @@ const USER_AGENT =
   'Dota2AbilityDraftPlusOverlay/2.0 (https://github.com/tiarin-hino/ability-draft-plus; dev@example.com)'
 
 /**
- * Maps keyboard hotkeys to ability ordering metadata.
- * Q/W/E are standard abilities (order 1-3), R is the ultimate (order 0).
+ * Standard ability hotkeys mapped to ability_order. Any OTHER non-empty hotkey
+ * (R, F, D, ...) is treated as an ultimate candidate — see the dev-guide above.
  */
-const HOTKEY_MAPPING: Record<string, { abilityOrder: number; isUltimate: boolean }> = {
-  Q: { abilityOrder: 1, isUltimate: false },
-  W: { abilityOrder: 2, isUltimate: false },
-  E: { abilityOrder: 3, isUltimate: false },
-  R: { abilityOrder: 0, isUltimate: true },
+const STANDARD_HOTKEY_ORDER: Record<string, number> = {
+  Q: 1,
+  W: 2,
+  E: 3,
 }
 
 /**
@@ -90,9 +96,14 @@ const HERO_NAME_OVERRIDES: Record<string, string> = {
 // ── Public Interface ────────────────────────────────────────────────────────────
 
 export interface LiquipediaAbilityUpdate {
-  abilityName: string
+  /** Hero page name this update came from, exactly as passed to enrichFromLiquipedia */
+  heroPageName: string
+  /** Ability display name as rendered on Liquipedia, e.g. "Shadow Step" */
+  abilityDisplayName: string
+  /** 1-3 for Q/W/E hotkeys; 0 for ultimate candidates */
   abilityOrder: number
-  isUltimate: boolean
+  /** True for any non-Q/W/E hotkey — must be confirmed against Windrun's is_ultimate */
+  isUltimateCandidate: boolean
 }
 
 // ── Core Logic ──────────────────────────────────────────────────────────────────
@@ -123,7 +134,7 @@ export async function enrichFromLiquipedia(
 
     try {
       const updates = await fetchHeroAbilities(pageTitle)
-      allUpdates.push(...updates)
+      allUpdates.push(...updates.map((u) => ({ ...u, heroPageName: heroName })))
       onProgress(
         `[${i + 1}/${heroNames.length}] Found ${updates.length} abilities for "${pageTitle}"`,
       )
@@ -152,10 +163,13 @@ export async function enrichFromLiquipedia(
 
 // ── Internal Helpers ────────────────────────────────────────────────────────────
 
+/** A spellcard parsed from one hero page, before the hero page name is attached. */
+export type ParsedSpellcard = Omit<LiquipediaAbilityUpdate, 'heroPageName'>
+
 /**
  * Fetches and parses a single hero's Liquipedia page, returning ability metadata.
  */
-async function fetchHeroAbilities(pageTitle: string): Promise<LiquipediaAbilityUpdate[]> {
+async function fetchHeroAbilities(pageTitle: string): Promise<ParsedSpellcard[]> {
   const url = `${LIQUIPEDIA_API_BASE}?action=parse&page=${encodeURIComponent(pageTitle)}&format=json`
 
   const response = await fetch(url, {
@@ -184,36 +198,39 @@ async function fetchHeroAbilities(pageTitle: string): Promise<LiquipediaAbilityU
  * Parses ability cards from Liquipedia's rendered HTML.
  *
  * Liquipedia renders each ability as a `.spellcard-wrapper` element with an ID
- * matching the ability name (underscores for spaces, no periods). Inside each
- * wrapper, a `div[title="Default Hotkey"] span` contains the hotkey character.
+ * matching the ability DISPLAY name (underscores for spaces, no periods). Inside
+ * each wrapper, a `div[title="Default Hotkey"] span` contains the hotkey character.
+ *
+ * Exported for unit testing.
  */
-function parseAbilitiesFromHtml(html: string): LiquipediaAbilityUpdate[] {
+export function parseAbilitiesFromHtml(html: string): ParsedSpellcard[] {
   const $ = cheerio.load(html)
-  const updates: LiquipediaAbilityUpdate[] = []
+  const updates: ParsedSpellcard[] = []
 
   $('.spellcard-wrapper').each((_index, element) => {
     const wrapper = $(element)
     const id = wrapper.attr('id')
     if (!id) return
 
-    // The ID is the ability name with underscores for spaces (no periods)
+    // The ID is the display name with underscores for spaces (no periods)
     // Convert back to display name: underscores → spaces
-    const abilityName = id.replace(/_/g, ' ')
+    const abilityDisplayName = id.replace(/_/g, ' ')
 
     // Find the hotkey character
     const hotkeySpan = wrapper.find('div[title="Default Hotkey"] span').first()
     const hotkeyChar = hotkeySpan.text().trim().toUpperCase()
 
-    if (!hotkeyChar || !(hotkeyChar in HOTKEY_MAPPING)) {
-      return // Skip abilities without Q/W/E/R hotkeys (innates, Aghs/Shard, etc.)
+    if (!hotkeyChar) {
+      return // No hotkey: innates, Aghs/Shard grants, hero model cards, etc.
     }
 
-    const mapping = HOTKEY_MAPPING[hotkeyChar]
-    updates.push({
-      abilityName,
-      abilityOrder: mapping.abilityOrder,
-      isUltimate: mapping.isUltimate,
-    })
+    const standardOrder = STANDARD_HOTKEY_ORDER[hotkeyChar]
+    if (standardOrder !== undefined) {
+      updates.push({ abilityDisplayName, abilityOrder: standardOrder, isUltimateCandidate: false })
+    } else {
+      // R, F, D, ... — ultimate candidate; confirmed against Windrun data at apply time
+      updates.push({ abilityDisplayName, abilityOrder: 0, isUltimateCandidate: true })
+    }
   })
 
   return updates

--- a/src/core/scraper/orchestrator.ts
+++ b/src/core/scraper/orchestrator.ts
@@ -8,6 +8,7 @@ import {
   buildAbilityLookup,
 } from './data-transformer'
 import { detectModelGaps } from '@core/ml/staleness-detector'
+import type { LiquipediaAbilityUpdate } from './liquipedia-scraper'
 import type { HeroRepository } from '@core/database/repositories/hero-repository'
 import type { AbilityRepository } from '@core/database/repositories/ability-repository'
 import type { SynergyRepository } from '@core/database/repositories/synergy-repository'
@@ -15,7 +16,10 @@ import type { TripletRepository } from '@core/database/repositories/triplet-repo
 import type { MetadataRepository } from '@core/database/repositories/metadata-repository'
 
 // @DEV-GUIDE: 3-phase scrape flow controller.
-// Phase 1: Fetch static data + ability/hero stats from Windrun, transform, upsert into DB.
+// Phase 1: Fetch static data + ability/hero stats from Windrun, transform, upsert into DB,
+// then prune ability rows absent from the fresh scrape (removed/renamed in a patch).
+// Without the prune, stale rows accumulate forever and produce false "missingFromModel"
+// warnings once a retrained model drops the legacy class names.
 // Phase 2: Fetch ability pairs + triplets, calculate synergy_increase, bulk insert into DB.
 // After success: records last_scrape_date, optionally runs ML staleness detection.
 // Each phase has progress callbacks for the UI scraping page.
@@ -43,7 +47,7 @@ export interface LiquipediaDeps {
   enrichFromLiquipedia: (
     heroNames: string[],
     onProgress: (msg: string) => void,
-  ) => Promise<{ abilityName: string; abilityOrder: number; isUltimate: boolean }[]>
+  ) => Promise<LiquipediaAbilityUpdate[]>
 }
 
 export async function performFullScrape(
@@ -107,6 +111,18 @@ export async function performFullScrape(
       })),
       heroNameToIdMap,
     )
+
+    // Prune abilities that dropped out of the Windrun data (removed/renamed in a patch).
+    // Must happen before phase 2 (getNameToIdMap) and before staleness detection
+    // (getAllNames), so neither sees stale rows. FK cascades remove dependent
+    // synergy/triplet rows; phase 2 rebuilds them from fresh data anyway.
+    const prunedNames = deps.abilities.deleteAbilitiesNotIn(abilityData.map((a) => a.name))
+    if (prunedNames.length > 0) {
+      onProgress({
+        phase: 'phase1',
+        message: `Pruned ${prunedNames.length} stale abilities: ${prunedNames.join(', ')}`,
+      })
+    }
     deps.persist()
 
     // ── Phase 2: Pairs & Triplets ──────────────────────────────────────────
@@ -216,6 +232,10 @@ export async function performLiquipediaEnrichment(
     onProgress({ phase: 'liquipedia', message: 'Starting Liquipedia enrichment...' })
 
     const heroPageNames = heroDisplayNames.map((name) => name.replace(/ /g, '_'))
+    // Map page names back to the DB display names for per-hero matching
+    const pageNameToDisplayName = new Map(
+      heroDisplayNames.map((name) => [name.replace(/ /g, '_'), name]),
+    )
     const updates = await deps.enrichFromLiquipedia(heroPageNames, (msg) => {
       onProgress({ phase: 'liquipedia', message: msg })
     })
@@ -226,11 +246,12 @@ export async function performLiquipediaEnrichment(
         message: `Applying ${updates.length} Liquipedia updates...`,
       })
 
-      const applied = deps.abilities.updateAbilityMeta(
+      const applied = deps.abilities.applyLiquipediaMeta(
         updates.map((u) => ({
-          name: u.abilityName,
+          heroDisplayName: pageNameToDisplayName.get(u.heroPageName) ?? u.heroPageName,
+          abilityDisplayName: u.abilityDisplayName,
           abilityOrder: u.abilityOrder,
-          isUltimate: u.isUltimate,
+          isUltimateCandidate: u.isUltimateCandidate,
         })),
       )
 

--- a/tests/unit/core/database/ability-repository.test.ts
+++ b/tests/unit/core/database/ability-repository.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
 import { createAbilityRepository, type AbilityRepository } from '@core/database/repositories/ability-repository'
 import { createTestDb, seedTestData, type TestDb } from './test-helpers'
 
@@ -95,34 +95,155 @@ describe('AbilityRepository', () => {
     })
   })
 
-  describe('updateAbilityMeta', () => {
-    it('updates abilityOrder and isUltimate for existing abilities', () => {
-      const count = repo.updateAbilityMeta([
-        { name: 'antimage_mana_break', abilityOrder: 10, isUltimate: true },
-      ])
-      expect(count).toBe(1)
+})
 
-      const details = repo.getDetails(['antimage_mana_break'])
-      const ability = details.get('antimage_mana_break')
-      expect(ability!.abilityOrder).toBe(10)
-      expect(ability!.isUltimate).toBe(true)
+// Separate DB instance: these tests mutate ability_order/is_ultimate
+describe('AbilityRepository.applyLiquipediaMeta', () => {
+  let testDb: TestDb
+  let repo: AbilityRepository
 
-      // Restore original values
-      repo.updateAbilityMeta([
-        { name: 'antimage_mana_break', abilityOrder: 1, isUltimate: false },
-      ])
-    })
+  beforeEach(async () => {
+    testDb = await createTestDb()
+    seedTestData(testDb.db)
+    repo = createAbilityRepository(testDb.db)
+  })
 
-    it('returns 0 for non-existent ability names', () => {
-      const count = repo.updateAbilityMeta([
-        { name: 'nonexistent_ability', abilityOrder: 1, isUltimate: false },
-      ])
-      expect(count).toBe(0)
-    })
+  afterEach(() => {
+    testDb.close()
+  })
 
-    it('handles empty updates array', () => {
-      const count = repo.updateAbilityMeta([])
-      expect(count).toBe(0)
-    })
+  it('applies Q/W/E updates matched by ability + hero display name', () => {
+    const applied = repo.applyLiquipediaMeta([
+      {
+        heroDisplayName: 'Anti-Mage',
+        abilityDisplayName: 'Mana Break',
+        abilityOrder: 3,
+        isUltimateCandidate: false,
+      },
+    ])
+
+    expect(applied).toBe(1)
+    const ability = repo.getDetails(['antimage_mana_break']).get('antimage_mana_break')
+    expect(ability!.abilityOrder).toBe(3)
+    expect(ability!.isUltimate).toBe(false)
+  })
+
+  it('applies an ultimate candidate when the DB row is an ultimate', () => {
+    // antimage_mana_void is seeded with isUltimate: true, abilityOrder: 4
+    const applied = repo.applyLiquipediaMeta([
+      {
+        heroDisplayName: 'Anti-Mage',
+        abilityDisplayName: 'Mana Void',
+        abilityOrder: 0,
+        isUltimateCandidate: true,
+      },
+    ])
+
+    expect(applied).toBe(1)
+    const ability = repo.getDetails(['antimage_mana_void']).get('antimage_mana_void')
+    expect(ability!.abilityOrder).toBe(0)
+    expect(ability!.isUltimate).toBe(true)
+  })
+
+  it('skips an ultimate candidate when the DB row is NOT an ultimate', () => {
+    // Simulates a hotkeyed sub-ability (e.g. Spectre's Reality on D)
+    const applied = repo.applyLiquipediaMeta([
+      {
+        heroDisplayName: 'Anti-Mage',
+        abilityDisplayName: 'Blink',
+        abilityOrder: 0,
+        isUltimateCandidate: true,
+      },
+    ])
+
+    expect(applied).toBe(0)
+    const ability = repo.getDetails(['antimage_blink']).get('antimage_blink')
+    expect(ability!.abilityOrder).toBe(2) // unchanged from seed
+    expect(ability!.isUltimate).toBe(false)
+  })
+
+  it('does not match the same ability display name under a different hero', () => {
+    const applied = repo.applyLiquipediaMeta([
+      {
+        heroDisplayName: 'Pudge',
+        abilityDisplayName: 'Mana Break',
+        abilityOrder: 1,
+        isUltimateCandidate: false,
+      },
+    ])
+
+    expect(applied).toBe(0)
+    const ability = repo.getDetails(['antimage_mana_break']).get('antimage_mana_break')
+    expect(ability!.abilityOrder).toBe(1) // unchanged from seed
+  })
+
+  it('skips unknown display names and handles empty input', () => {
+    expect(
+      repo.applyLiquipediaMeta([
+        {
+          heroDisplayName: 'Anti-Mage',
+          abilityDisplayName: 'Nonexistent Spell',
+          abilityOrder: 1,
+          isUltimateCandidate: false,
+        },
+      ]),
+    ).toBe(0)
+    expect(repo.applyLiquipediaMeta([])).toBe(0)
+  })
+})
+
+// Separate DB instance: these tests delete rows and would corrupt the shared fixture above
+describe('AbilityRepository.deleteAbilitiesNotIn', () => {
+  let testDb: TestDb
+  let repo: AbilityRepository
+
+  beforeEach(async () => {
+    testDb = await createTestDb()
+    seedTestData(testDb.db)
+    repo = createAbilityRepository(testDb.db)
+  })
+
+  afterEach(() => {
+    testDb.close()
+  })
+
+  it('deletes abilities not in keepNames and returns their names', () => {
+    const keep = repo.getAllNames().filter((n) => n !== 'pudge_rot' && n !== 'invoker_quas')
+
+    const deleted = repo.deleteAbilitiesNotIn(keep)
+
+    expect(deleted.sort()).toEqual(['invoker_quas', 'pudge_rot'])
+    const remaining = repo.getAllNames()
+    expect(remaining).not.toContain('pudge_rot')
+    expect(remaining).not.toContain('invoker_quas')
+    expect(remaining).toContain('antimage_mana_break')
+  })
+
+  it('returns empty array when everything is kept', () => {
+    const deleted = repo.deleteAbilitiesNotIn(repo.getAllNames())
+
+    expect(deleted).toEqual([])
+    expect(repo.getAllNames().length).toBeGreaterThan(0)
+  })
+
+  it('is a no-op for empty keepNames (never wipes the table)', () => {
+    const before = repo.getAllNames().length
+
+    const deleted = repo.deleteAbilitiesNotIn([])
+
+    expect(deleted).toEqual([])
+    expect(repo.getAllNames().length).toBe(before)
+  })
+
+  it('cascades deletion of dependent synergy rows', () => {
+    // frostbite (abilityId 6) participates in seeded AbilitySynergies rows
+    const keep = repo.getAllNames().filter((n) => n !== 'crystal_maiden_frostbite')
+
+    repo.deleteAbilitiesNotIn(keep)
+
+    const orphans = testDb.sqlite.exec(
+      'SELECT COUNT(*) FROM AbilitySynergies WHERE base_ability_id = 6 OR synergy_ability_id = 6',
+    )
+    expect(orphans[0].values[0][0]).toBe(0)
   })
 })

--- a/tests/unit/core/scraper/liquipedia-scraper.test.ts
+++ b/tests/unit/core/scraper/liquipedia-scraper.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { parseAbilitiesFromHtml } from '@core/scraper/liquipedia-scraper'
+
+// Fixture mirrors the real structure of Liquipedia hero pages (verified against the
+// live Spectre page): spellcard IDs are DISPLAY names, hotkeys include non-R ultimates
+// (Haunt on F) and hotkeyed sub-abilities (Reality on D).
+function spellcard(id: string | null, hotkey: string | null): string {
+  const idAttr = id ? ` id="${id}"` : ''
+  const hotkeyDiv = hotkey
+    ? `<div title="Default Hotkey"><span>${hotkey}</span></div>`
+    : ''
+  return `<div class="spellcard-wrapper"${idAttr}>${hotkeyDiv}</div>`
+}
+
+const SPECTRE_LIKE_HTML = [
+  spellcard('Desolate', null), // innate — no hotkey
+  spellcard('Hero_Model', null), // non-ability card
+  spellcard(null, null), // wrapper without id
+  spellcard('Spectral_Dagger', 'Q'),
+  spellcard('Shadow_Step', 'W'),
+  spellcard('Dispersion', 'E'),
+  spellcard('Haunt', 'F'), // ultimate NOT on R
+  spellcard('Reality', 'D'), // hotkeyed sub-ability
+].join('\n')
+
+describe('parseAbilitiesFromHtml', () => {
+  it('maps Q/W/E hotkeys to ability_order 1/2/3 with display names', () => {
+    const result = parseAbilitiesFromHtml(SPECTRE_LIKE_HTML)
+
+    expect(result).toContainEqual({
+      abilityDisplayName: 'Spectral Dagger',
+      abilityOrder: 1,
+      isUltimateCandidate: false,
+    })
+    expect(result).toContainEqual({
+      abilityDisplayName: 'Shadow Step',
+      abilityOrder: 2,
+      isUltimateCandidate: false,
+    })
+    expect(result).toContainEqual({
+      abilityDisplayName: 'Dispersion',
+      abilityOrder: 3,
+      isUltimateCandidate: false,
+    })
+  })
+
+  it('marks any non-Q/W/E hotkey as an ultimate candidate', () => {
+    const result = parseAbilitiesFromHtml(SPECTRE_LIKE_HTML)
+
+    // Both the real ultimate (F) and the sub-ability (D) are candidates here;
+    // applyLiquipediaMeta filters candidates against Windrun's is_ultimate.
+    expect(result).toContainEqual({
+      abilityDisplayName: 'Haunt',
+      abilityOrder: 0,
+      isUltimateCandidate: true,
+    })
+    expect(result).toContainEqual({
+      abilityDisplayName: 'Reality',
+      abilityOrder: 0,
+      isUltimateCandidate: true,
+    })
+  })
+
+  it('skips cards without a hotkey or without an id', () => {
+    const result = parseAbilitiesFromHtml(SPECTRE_LIKE_HTML)
+
+    expect(result).toHaveLength(5)
+    const names = result.map((r) => r.abilityDisplayName)
+    expect(names).not.toContain('Desolate')
+    expect(names).not.toContain('Hero Model')
+  })
+
+  it('maps R hotkeys as ultimate candidates too', () => {
+    const result = parseAbilitiesFromHtml(spellcard('Mana_Void', 'R'))
+
+    expect(result).toEqual([
+      { abilityDisplayName: 'Mana Void', abilityOrder: 0, isUltimateCandidate: true },
+    ])
+  })
+
+  it('returns empty array for HTML without spellcards', () => {
+    expect(parseAbilitiesFromHtml('<div><p>No abilities here</p></div>')).toEqual([])
+  })
+})

--- a/tests/unit/core/scraper/orchestrator.test.ts
+++ b/tests/unit/core/scraper/orchestrator.test.ts
@@ -80,9 +80,10 @@ function createMockDeps(apiClient?: WindrunApiClient): ScraperDeps {
     } as unknown as ScraperDeps['heroes'],
     abilities: {
       upsertAbilities: vi.fn(),
+      deleteAbilitiesNotIn: vi.fn().mockReturnValue([]),
       getNameToIdMap: vi.fn().mockReturnValue(new Map([['ursa_fury_swipes', 100]])),
       getAllNames: vi.fn().mockReturnValue(['ursa_fury_swipes']),
-      updateAbilityMeta: vi.fn().mockReturnValue(1),
+      applyLiquipediaMeta: vi.fn().mockReturnValue(1),
       getAll: vi.fn().mockReturnValue([]),
       getById: vi.fn(),
       getByName: vi.fn(),
@@ -154,6 +155,25 @@ describe('performFullScrape', () => {
 
     expect(deps.heroes.upsertHeroes).toHaveBeenCalledOnce()
     expect(deps.abilities.upsertAbilities).toHaveBeenCalledOnce()
+  })
+
+  it('prunes abilities absent from the fresh scrape after upserting', async () => {
+    await performFullScrape(deps, onProgress)
+
+    expect(deps.abilities.deleteAbilitiesNotIn).toHaveBeenCalledOnce()
+    expect(deps.abilities.deleteAbilitiesNotIn).toHaveBeenCalledWith(['ursa_fury_swipes'])
+  })
+
+  it('reports pruned stale abilities via progress', async () => {
+    ;(deps.abilities.deleteAbilitiesNotIn as ReturnType<typeof vi.fn>).mockReturnValue([
+      'dragon_knight_dragon_blood',
+    ])
+
+    await performFullScrape(deps, onProgress)
+
+    const pruneMessage = progress.find((p) => p.message.includes('Pruned 1 stale abilities'))
+    expect(pruneMessage).toBeDefined()
+    expect(pruneMessage!.message).toContain('dragon_knight_dragon_blood')
   })
 
   it('persists after each phase', async () => {
@@ -263,25 +283,46 @@ describe('performLiquipediaEnrichment', () => {
     progress = []
   })
 
-  it('applies Liquipedia updates via updateAbilityMeta', async () => {
-    const updateAbilityMeta = vi.fn().mockReturnValue(2)
+  it('applies Liquipedia updates via applyLiquipediaMeta with hero display names', async () => {
+    const applyLiquipediaMeta = vi.fn().mockReturnValue(2)
     const deps: LiquipediaDeps = {
       abilities: {
-        updateAbilityMeta,
+        applyLiquipediaMeta,
       } as unknown as LiquipediaDeps['abilities'],
       persist: vi.fn(),
       enrichFromLiquipedia: vi.fn().mockResolvedValue([
-        { abilityName: 'ursa_fury_swipes', abilityOrder: 3, isUltimate: false },
-        { abilityName: 'ursa_enrage', abilityOrder: 0, isUltimate: true },
+        {
+          heroPageName: 'Drow_Ranger',
+          abilityDisplayName: 'Frost Arrows',
+          abilityOrder: 1,
+          isUltimateCandidate: false,
+        },
+        {
+          heroPageName: 'Drow_Ranger',
+          abilityDisplayName: 'Marksmanship',
+          abilityOrder: 0,
+          isUltimateCandidate: true,
+        },
       ]),
     }
 
-    const result = await performLiquipediaEnrichment(deps, ['Ursa'], onProgress)
+    const result = await performLiquipediaEnrichment(deps, ['Drow Ranger'], onProgress)
 
     expect(result.success).toBe(true)
-    expect(updateAbilityMeta).toHaveBeenCalledWith([
-      { name: 'ursa_fury_swipes', abilityOrder: 3, isUltimate: false },
-      { name: 'ursa_enrage', abilityOrder: 0, isUltimate: true },
+    // Page names ("Drow_Ranger") must be translated back to DB display names ("Drow Ranger")
+    expect(applyLiquipediaMeta).toHaveBeenCalledWith([
+      {
+        heroDisplayName: 'Drow Ranger',
+        abilityDisplayName: 'Frost Arrows',
+        abilityOrder: 1,
+        isUltimateCandidate: false,
+      },
+      {
+        heroDisplayName: 'Drow Ranger',
+        abilityDisplayName: 'Marksmanship',
+        abilityOrder: 0,
+        isUltimateCandidate: true,
+      },
     ])
     expect(deps.persist).toHaveBeenCalled()
   })
@@ -289,7 +330,7 @@ describe('performLiquipediaEnrichment', () => {
   it('handles empty updates gracefully', async () => {
     const deps: LiquipediaDeps = {
       abilities: {
-        updateAbilityMeta: vi.fn(),
+        applyLiquipediaMeta: vi.fn(),
       } as unknown as LiquipediaDeps['abilities'],
       persist: vi.fn(),
       enrichFromLiquipedia: vi.fn().mockResolvedValue([]),
@@ -298,14 +339,14 @@ describe('performLiquipediaEnrichment', () => {
     const result = await performLiquipediaEnrichment(deps, ['Ursa'], onProgress)
 
     expect(result.success).toBe(true)
-    expect(deps.abilities.updateAbilityMeta).not.toHaveBeenCalled()
+    expect(deps.abilities.applyLiquipediaMeta).not.toHaveBeenCalled()
     expect(deps.persist).not.toHaveBeenCalled()
   })
 
   it('returns error on failure', async () => {
     const deps: LiquipediaDeps = {
       abilities: {
-        updateAbilityMeta: vi.fn(),
+        applyLiquipediaMeta: vi.fn(),
       } as unknown as LiquipediaDeps['abilities'],
       persist: vi.fn(),
       enrichFromLiquipedia: vi.fn().mockRejectedValue(new Error('Rate limited')),
@@ -321,7 +362,7 @@ describe('performLiquipediaEnrichment', () => {
     const enrichFn = vi.fn().mockResolvedValue([])
     const deps: LiquipediaDeps = {
       abilities: {
-        updateAbilityMeta: vi.fn(),
+        applyLiquipediaMeta: vi.fn(),
       } as unknown as LiquipediaDeps['abilities'],
       persist: vi.fn(),
       enrichFromLiquipedia: enrichFn,


### PR DESCRIPTION
## Summary

Two data-pipeline correctness fixes, both found while investigating false ML staleness warnings after the v2.4.0 retrain.

### 1. Prune stale ability rows after the Windrun scrape

The scrape was upsert-only: abilities removed/renamed in patches (`dragon_knight_dragon_blood` → `dragon_knight_wyrms_wrath`, `spectre_haunt_single` → `spectre_haunt`, `beastmaster_call_of_the_wild_hawk` → `beastmaster_summon_raptor`, …) stayed in the DB forever with years-old winrates. Once the v2.4.0 retrain purged the legacy class names, staleness detection (which reads `getAllNames()`, i.e. the whole DB) flagged these zombie rows as false `missingFromModel` warnings ("model needs retraining" for abilities that no longer exist).

- New `AbilityRepository.deleteAbilitiesNotIn(keepNames)` — deletes rows absent from the fresh scrape, returns the pruned names; deliberate no-op on empty input so a failed/empty scrape can never wipe the table.
- Called in `performFullScrape` right after the phase-1 upsert, before phase 2 (`getNameToIdMap`) and staleness detection see the data. FK cascades clean up dependent synergy/triplet rows; phase 2 rebuilds them from fresh data anyway.
- Verified live: pruned 19 zombie rows (some dating to pre-7.36 innate reworks); `missingFromModel` went to 0 and `staleInModel` now correctly lists the 16 legacy classes still in the model — dataset-cleanup candidates for the next retrain.

### 2. Repair Liquipedia enrichment matching (it never worked in v2)

Evidence: no `liquipedia_last_updated` metadata key on a long-lived install, and 18 post-v1 abilities with `NULL ability_order` (Largo's kit, `spectre_shadow_step`, `dragon_knight_wyrms_wrath`, …) — which feeds the known `ability_order === 2` hero-identification fragility.

Two independent bugs, verified against the live Liquipedia Spectre page:

- **Name mismatch:** spellcard IDs are display names (`Shadow_Step` → "Shadow Step") but `updateAbilityMeta` matched the internal `name` column (`spectre_shadow_step`) — every update silently skipped ("Applied 0 of N").
- **Non-R ultimates dropped:** the hotkey map only knew Q/W/E/R, but Spectre's Haunt sits on **F** (Reality on D). Ults not on R were skipped before the name bug even mattered.

Fix: replaced `updateAbilityMeta` with `applyLiquipediaMeta`:

- Matches per-hero by `display_name` (updates now carry `heroPageName`; the orchestrator translates page names back to DB hero display names), avoiding cross-hero display-name collisions.
- Any non-Q/W/E hotkey marks an **ultimate candidate**, applied as `ability_order = 0` only when the DB row is already `is_ultimate` per Windrun data — this admits F/D-hotkey ults while filtering hotkeyed sub-abilities like Spectre's Reality.

## Test plan

- [x] New unit tests: `deleteAbilitiesNotIn` (keep/delete/empty-guard/FK cascade), `applyLiquipediaMeta` (Q/W/E match, ult candidate accepted/rejected, hero scoping, unknown names), `parseAbilitiesFromHtml` (fixture mirroring the real Spectre page: display-name IDs, F-hotkey ult, D-hotkey sub-ability, hotkey-less innate)
- [x] Updated orchestrator tests for the prune call and the new enrichment shape
- [x] Full suite: 399 tests pass; typecheck and ESLint clean
- [x] Live-verified the prune end-to-end via `npm run dev` → Update Data (log shows the 19 pruned names, `missingFromModel: 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
