### PR TITLE
feat(ml): mask removed-from-pool classes at inference + repair scraper slot data

### DIFF
--- a/src/core/database/repositories/ability-repository.ts
+++ b/src/core/database/repositories/ability-repository.ts
@@ -56,6 +56,14 @@ export interface AbilityRepository {
   getNameToIdMap(): Map<string, number>
   getAllNames(): string[]
   applyLiquipediaMeta(updates: LiquipediaMetaUpdate[]): number
+  /**
+   * Force ability_order/is_ultimate by internal name. Used for the hand-curated
+   * slot overrides (see scraper/slot-metadata-overrides.ts) — authoritative over
+   * both Windrun and Liquipedia. Returns the number of rows that matched.
+   */
+  setSlotMetadata(
+    entries: Array<{ name: string; abilityOrder: number; isUltimate: boolean }>,
+  ): number
 }
 
 function mapRow(row: typeof abilities.$inferSelect): AbilityDetail {
@@ -171,6 +179,29 @@ export function createAbilityRepository(db: SQLJsDatabase): AbilityRepository {
         .from(abilities)
         .all()
         .map((row) => row.name)
+    },
+
+    setSlotMetadata(
+      entries: Array<{ name: string; abilityOrder: number; isUltimate: boolean }>,
+    ): number {
+      if (entries.length === 0) return 0
+      // sql.js run() doesn't report changes — count matches via SELECT first
+      const existing = new Set(
+        db
+          .select({ name: abilities.name })
+          .from(abilities)
+          .where(inArray(abilities.name, entries.map((e) => e.name)))
+          .all()
+          .map((row) => row.name),
+      )
+      for (const entry of entries) {
+        if (!existing.has(entry.name)) continue
+        db.update(abilities)
+          .set({ abilityOrder: entry.abilityOrder, isUltimate: entry.isUltimate })
+          .where(eq(abilities.name, entry.name))
+          .run()
+      }
+      return existing.size
     },
 
     applyLiquipediaMeta(updates: LiquipediaMetaUpdate[]): number {

--- a/src/core/domain/scan-processor.ts
+++ b/src/core/domain/scan-processor.ts
@@ -485,7 +485,11 @@ type HeroSynergyMap = Map<
 
 // @DEV-GUIDE: Attaches all enrichment data to each scan slot for overlay rendering.
 // Merges DB details, synergy lists, top-tier flags, and consolidated scores onto each slot.
-// Unknown abilities (name === null) get a safe fallback via makeUnknownSlot().
+// Unknown abilities (name === null) get a safe fallback via makeUnknownSlot(); so do
+// predicted names with no DB row (ability removed from the pool / DB not yet scraped) —
+// rendering those as normal slots would show raw internal names with a fake neutral score.
+// (Class masking in the ML worker normally prevents removed-class predictions upstream;
+// this is the defense-in-depth net for when masking is unavailable.)
 function enrichSlots(
   slots: ScanResult[],
   abilityDetailsMap: Map<string, import('@shared/types').AbilityDetail>,
@@ -505,6 +509,9 @@ function enrichSlots(
     }
 
     const details = abilityDetailsMap.get(slot.name)
+    if (!details) {
+      return makeUnknownSlot(slot)
+    }
     const synergies = abilitySynergyMap.get(slot.name)
     const heroSyn = abilityHeroSynergyMap.get(slot.name)
     const topTier = topTierLookup.get(slot.name)
@@ -512,17 +519,17 @@ function enrichSlots(
 
     return {
       ...slot,
-      displayName: details?.displayName ?? slot.name,
-      winrate: details?.winrate ?? null,
-      pickRate: details?.pickRate ?? null,
+      displayName: details.displayName,
+      winrate: details.winrate,
+      pickRate: details.pickRate,
       consolidatedScore: scored?.consolidatedScore ?? calculateConsolidatedScore(
-        details?.winrate ?? null,
-        details?.pickRate ?? null,
+        details.winrate,
+        details.pickRate,
       ),
       isGeneralTopTier: topTier?.isGeneralTopTier ?? false,
       isSynergySuggestionForMySpot:
         topTier?.isSynergySuggestionForMySpot ?? false,
-      isUltimateFromDb: details?.isUltimate ?? false,
+      isUltimateFromDb: details.isUltimate,
       highWinrateCombinations: synergies?.high ?? [],
       lowWinrateCombinations: synergies?.low ?? [],
       strongHeroSynergies: heroSyn?.strong ?? [],

--- a/src/core/ml/classifier.ts
+++ b/src/core/ml/classifier.ts
@@ -12,10 +12,16 @@ export interface ClassifierResult {
 
 export interface ImageClassifier {
   initialize(config: ClassifierConfig): Promise<void>
+  /**
+   * @param activeClassNames When provided (non-empty), classes NOT in the set are
+   * excluded from prediction — used to mask model classes for abilities that left
+   * the draft pool but are kept in the model in case they return.
+   */
   classify(
     batchData: Float32Array,
     batchSize: number,
     confidenceThreshold: number,
+    activeClassNames?: ReadonlySet<string>,
   ): Promise<ClassifierResult[]>
   dispose(): Promise<void>
   isReady(): boolean

--- a/src/core/ml/onnx-classifier.ts
+++ b/src/core/ml/onnx-classifier.ts
@@ -12,6 +12,12 @@ import type { ClassifierConfig, ClassifierResult, ImageClassifier } from './clas
 // Warmup inference runs on init to trigger JIT compilation.
 // classifyBatch() takes pre-processed float32 arrays and returns className + confidence pairs.
 // Returns null className if confidence < threshold (0.9).
+// Class masking: classify() optionally takes the set of active class names (the abilities
+// currently in the DB, i.e. still in the draft pool). Classes outside the set are skipped
+// during argmax, so a removed-from-pool ability that is still in the model can never be
+// predicted — the next-best active class wins, or the slot falls below the threshold and
+// renders Unknown. An ability returning to the pool re-enters the set automatically via
+// the Windrun scrape; the model keeps its trained classes either way.
 // Zero Electron imports -- runs in the ML worker (worker_threads).
 
 export function createOnnxClassifier(): ImageClassifier {
@@ -73,9 +79,19 @@ export function createOnnxClassifier(): ImageClassifier {
     batchData: Float32Array,
     batchSize: number,
     confidenceThreshold: number,
+    activeClassNames?: ReadonlySet<string>,
   ): Promise<ClassifierResult[]> {
     if (!session || !ready) {
       throw new Error('Classifier not initialized')
+    }
+
+    // Mask classes absent from the active set (abilities removed from the draft
+    // pool). If the set would exclude EVERY class (empty DB, or a DB/model naming
+    // mismatch), fall back to unmasked — a broken mask must not blind the scanner.
+    let excluded: boolean[] | null = null
+    if (activeClassNames && activeClassNames.size > 0) {
+      excluded = classNames.map((n) => !activeClassNames.has(n))
+      if (excluded.every(Boolean)) excluded = null
     }
 
     const tensor = new ort.Tensor('float32', batchData, [
@@ -96,6 +112,7 @@ export function createOnnxClassifier(): ImageClassifier {
       let maxProb = 0
       let maxIndex = 0
       for (let j = 0; j < numClasses; j++) {
+        if (excluded?.[j]) continue
         const val = outputData[offset + j]
         if (val > maxProb) {
           maxProb = val

--- a/src/core/scraper/data-transformer.ts
+++ b/src/core/scraper/data-transformer.ts
@@ -16,6 +16,10 @@ import type {
 // Handles ID mapping (Windrun IDs -> internal DB IDs), name normalization,
 // synergy pair extraction with synergy_increase calculation, and triplet formatting.
 // Key: Windrun shortNames are single concatenated words (e.g., "drowranger" not "drow_ranger").
+// Brand-new abilities can ship with ownerHeroId: null in Windrun's static data
+// (seen with 7.39 additions like dragon_knight_wyrms_wrath) — the hero is then
+// derived from the ability shortName prefix, since ability internal names are
+// always prefixed with the hero's internal name.
 //
 // Three transform functions match the three data categories:
 // - transformAbilitiesAndHeroes: Splits stats into hero vs ability entries (negative ID = hero)
@@ -48,6 +52,25 @@ export function buildAbilityLookup(abilities: WindrunStaticAbility[]): AbilityLo
 
 // ── Abilities & Heroes ───────────────────────────────────────────────────────
 
+/**
+ * Fallback hero linkage for abilities Windrun serves with ownerHeroId: null.
+ * Ability internal names are prefixed with the hero's internal name; hero
+ * shortNames are the same words concatenated ("dragonknight"). Longest match
+ * first so e.g. a "night_stalker_..." ability can never match a hypothetical
+ * shorter hero prefix.
+ */
+function deriveOwnerHero(
+  abilityShortName: string,
+  heroesByNameLength: WindrunStaticHero[],
+): WindrunStaticHero | null {
+  const flatName = abilityShortName.replace(/_/g, '').toLowerCase()
+  return (
+    heroesByNameLength.find((h) =>
+      flatName.startsWith(h.shortName.toLowerCase()),
+    ) ?? null
+  )
+}
+
 export function transformAbilitiesAndHeroes(
   overallStats: WindrunAbilityStat[],
   hsStats: WindrunAbilityStat[],
@@ -62,6 +85,10 @@ export function transformAbilitiesAndHeroes(
 
   const heroData: TransformedHero[] = []
   const abilityData: TransformedAbility[] = []
+
+  const heroesByNameLength = Object.values(staticHeroes).sort(
+    (a, b) => b.shortName.length - a.shortName.length,
+  )
 
   for (const stat of overallStats) {
     const hs = hsMap.get(stat.abilityId)
@@ -86,13 +113,15 @@ export function transformAbilitiesAndHeroes(
       const staticAbility = abilityLookup.get(stat.abilityId)
       if (!staticAbility) continue
 
-      const heroId = staticAbility.ownerHeroId
-      const staticHero = heroId ? staticHeroes[String(heroId)] : null
+      const ownerId = staticAbility.ownerHeroId
+      const staticHero =
+        (ownerId ? staticHeroes[String(ownerId)] : null) ??
+        deriveOwnerHero(staticAbility.shortName, heroesByNameLength)
 
       abilityData.push({
         name: staticAbility.shortName,
         displayName: staticAbility.englishName,
-        heroId: heroId || null,
+        heroId: staticHero?.id ?? null,
         heroName: staticHero?.shortName ?? null,
         winrate: stat.winrate,
         highSkillWinrate: hs?.winrate ?? null,

--- a/src/core/scraper/liquipedia-scraper.ts
+++ b/src/core/scraper/liquipedia-scraper.ts
@@ -44,11 +44,14 @@ const STANDARD_HOTKEY_ORDER: Record<string, number> = {
 }
 
 /**
- * Special-case hero name mappings from internal snake_case names to Liquipedia page titles.
- * Most heroes can be derived algorithmically, but these have punctuation or casing quirks
- * that the simple title-case + underscore replacement cannot handle.
+ * Special-case hero name mappings to Liquipedia page titles, keyed by a normalized
+ * form of the hero name (lowercase, apostrophes stripped, spaces/hyphens → "_") so
+ * both display names ("Anti-Mage") and internal snake_case names match. Needed for
+ * punctuation quirks and for heroes whose Liquipedia page uses a different name
+ * than the data source (Outworld Devourer → Outworld Destroyer).
  */
 const HERO_NAME_OVERRIDES: Record<string, string> = {
+  outworld_devourer: 'Outworld_Destroyer',
   anti_mage: 'Anti-Mage',
   natures_prophet: "Nature's_Prophet",
   shadow_fiend: 'Shadow_Fiend',
@@ -112,7 +115,8 @@ export interface LiquipediaAbilityUpdate {
  * Fetches ability metadata (ability_order, is_ultimate) for the given heroes
  * from Liquipedia's wiki API.
  *
- * @param heroNames - Internal hero names (snake_case), e.g. ["ursa", "anti_mage"]
+ * @param heroNames - Hero names as passed by the enrichment flow: display-name-derived
+ *   page names, e.g. ["Ursa", "Anti-Mage", "Queen_of_Pain"] (internal snake_case also accepted)
  * @param onProgress - Callback invoked with human-readable status messages
  * @returns Array of ability updates found across all heroes
  */
@@ -237,25 +241,45 @@ export function parseAbilitiesFromHtml(html: string): ParsedSpellcard[] {
 }
 
 /**
- * Converts an internal hero name (snake_case) to a Liquipedia page title.
+ * Converts a hero name to a Liquipedia page title. Accepts display-name-derived
+ * page names ("Queen_of_Pain", what the enrichment flow passes) as well as
+ * internal snake_case names ("queen_of_pain").
+ *
+ * Liquipedia page titles keep natural casing ("Queen_of_Pain", NOT "Queen_Of_Pain"),
+ * so the input's casing is preserved apart from the leading capital — display names
+ * are already correctly cased. Title-casing every word here caused real misses
+ * (Queen_Of_Pain / Keeper_Of_The_Light returned 0 abilities).
  *
  * Examples:
- *   "ursa"           → "Ursa"
- *   "anti_mage"      → "Anti-Mage"     (special case)
- *   "crystal_maiden"  → "Crystal_Maiden"
- *   "natures_prophet" → "Nature's_Prophet" (special case)
+ *   "ursa"            → "Ursa"
+ *   "Anti-Mage"       → "Anti-Mage"          (override, keyed "anti_mage")
+ *   "Queen_of_Pain"   → "Queen_of_Pain"      (override, keyed "queen_of_pain")
+ *   "Outworld_Devourer" → "Outworld_Destroyer" (override — Liquipedia uses the new name)
+ *   "Nature's_Prophet" → "Nature's_Prophet"  (override, keyed "natures_prophet")
  */
-function heroNameToPageTitle(internalName: string): string {
-  // Check overrides first
-  if (internalName in HERO_NAME_OVERRIDES) {
-    return HERO_NAME_OVERRIDES[internalName]
+export function heroNameToPageTitle(name: string): string {
+  // Normalize to the override key form: lowercase, apostrophes stripped,
+  // spaces/hyphens collapsed to underscores
+  const key = name
+    .toLowerCase()
+    .replace(/['’]/g, '')
+    .replace(/[\s-]+/g, '_')
+  if (key in HERO_NAME_OVERRIDES) {
+    return HERO_NAME_OVERRIDES[key]
   }
 
-  // Default: replace underscores with spaces, title-case each word, then join with underscores
-  return internalName
-    .split('_')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join('_')
+  // All-lowercase input = internal snake_case name → title-case each word
+  // ("death_prophet" → "Death_Prophet"). Names with connector words ("of", "the")
+  // must be in the overrides — blind title-casing produces page misses.
+  if (name === name.toLowerCase()) {
+    return name
+      .split('_')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join('_')
+  }
+
+  // Display-name-derived input ("Queen_of_Pain") — already correctly cased
+  return name
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/core/scraper/orchestrator.ts
+++ b/src/core/scraper/orchestrator.ts
@@ -8,6 +8,7 @@ import {
   buildAbilityLookup,
 } from './data-transformer'
 import { detectModelGaps } from '@core/ml/staleness-detector'
+import { SLOT_METADATA_OVERRIDES } from './slot-metadata-overrides'
 import type { LiquipediaAbilityUpdate } from './liquipedia-scraper'
 import type { HeroRepository } from '@core/database/repositories/hero-repository'
 import type { AbilityRepository } from '@core/database/repositories/ability-repository'
@@ -17,9 +18,13 @@ import type { MetadataRepository } from '@core/database/repositories/metadata-re
 
 // @DEV-GUIDE: 3-phase scrape flow controller.
 // Phase 1: Fetch static data + ability/hero stats from Windrun, transform, upsert into DB,
-// then prune ability rows absent from the fresh scrape (removed/renamed in a patch).
+// then prune ability rows absent from the fresh scrape (removed/renamed in a patch),
+// then apply hand-curated slot metadata overrides (slot-metadata-overrides.ts) — those
+// win over both Windrun and Liquipedia, and are re-applied after Liquipedia enrichment.
 // Without the prune, stale rows accumulate forever and produce false "missingFromModel"
-// warnings once a retrained model drops the legacy class names.
+// warnings once a retrained model drops the legacy class names. The prune also keeps
+// "DB ability names" === "abilities in the pool", which the scan pipeline relies on to
+// mask removed-from-pool model classes at inference (see ml-handlers / onnx-classifier).
 // Phase 2: Fetch ability pairs + triplets, calculate synergy_increase, bulk insert into DB.
 // After success: records last_scrape_date, optionally runs ML staleness detection.
 // Each phase has progress callbacks for the UI scraping page.
@@ -123,6 +128,11 @@ export async function performFullScrape(
         message: `Pruned ${prunedNames.length} stale abilities: ${prunedNames.join(', ')}`,
       })
     }
+
+    // Hand-curated slot corrections for abilities the scrapers can't get right
+    // (passives, non-QWER hotkeys, stale pre-rework rows) — authoritative.
+    applySlotOverrides(deps.abilities, onProgress, 'phase1')
+
     deps.persist()
 
     // ── Phase 2: Pairs & Triplets ──────────────────────────────────────────
@@ -218,6 +228,25 @@ export async function performFullScrape(
   }
 }
 
+function applySlotOverrides(
+  abilities: ScraperDeps['abilities'],
+  onProgress: (progress: ScraperProgress) => void,
+  phase: ScraperProgress['phase'],
+): void {
+  const entries = Object.entries(SLOT_METADATA_OVERRIDES).map(([name, o]) => ({
+    name,
+    abilityOrder: o.abilityOrder,
+    isUltimate: o.isUltimate,
+  }))
+  const applied = abilities.setSlotMetadata(entries)
+  if (applied > 0) {
+    onProgress({
+      phase,
+      message: `Applied ${applied} manual slot metadata overrides`,
+    })
+  }
+}
+
 /**
  * Separate Liquipedia enrichment — fetches ability_order and is_ultimate for
  * each hero's abilities. Rate-limited to 1 request per 31s (Liquipedia API policy).
@@ -259,6 +288,9 @@ export async function performLiquipediaEnrichment(
         phase: 'liquipedia',
         message: `Applied ${applied} of ${updates.length} Liquipedia updates`,
       })
+
+      // Re-apply hand-curated slot corrections — they win over Liquipedia too
+      applySlotOverrides(deps.abilities, onProgress, 'liquipedia')
 
       deps.persist()
     }

--- a/src/core/scraper/slot-metadata-overrides.ts
+++ b/src/core/scraper/slot-metadata-overrides.ts
@@ -1,0 +1,31 @@
+// @DEV-GUIDE: Hand-curated slot metadata (ability_order / is_ultimate) for abilities
+// neither scraper can get right, applied AFTER every Windrun scrape and after Liquipedia
+// enrichment — these entries are authoritative and win over both sources.
+// When they are needed: Liquipedia's spellcards only expose Q/W/E hotkeys reliably;
+// passives (no hotkey), non-QWER hotkeys (D/F), and stale rows that predate a kit
+// rework fall through and keep wrong or NULL ability_order. Verify each entry in-game
+// before adding it, and DELETE entries once the scrapers produce the right value on
+// their own (e.g. after a Liquipedia page fix) — every entry here shadows the scrapers.
+// Slot convention: ability_order 0 = ultimate, 1-3 = Q/W/E.
+
+export interface SlotMetadataOverride {
+  abilityOrder: number
+  isUltimate: boolean
+}
+
+export const SLOT_METADATA_OVERRIDES: Readonly<Record<string, SlotMetadataOverride>> = {
+  // Wrong in old Windrun-era data; verified in-game 2026-07: Healing Ward is W.
+  juggernaut_healing_ward: { abilityOrder: 2, isUltimate: false },
+  // Feast of Souls — hotkey D on Liquipedia, undetectable. Verified in-game: W slot.
+  nevermore_frenzy: { abilityOrder: 2, isUltimate: false },
+  // Presence of the Dark Lord — passive, no hotkey. Verified in-game: E slot
+  // (old data had it at W before Feast of Souls took that slot).
+  nevermore_dark_lord: { abilityOrder: 3, isUltimate: false },
+  // Passive (no hotkey on Liquipedia); replaced Blur in the E slot.
+  phantom_assassin_immaterial: { abilityOrder: 3, isUltimate: false },
+  // 7.39 additions shipped by Windrun with ownerHeroId: null and never enriched
+  // (rows had no hero linkage, so Liquipedia matching skipped them entirely).
+  dragon_knight_wyrms_wrath: { abilityOrder: 3, isUltimate: false },
+  venomancer_snakebite: { abilityOrder: 2, isUltimate: false },
+  tinker_deploy_turrets: { abilityOrder: 3, isUltimate: false },
+}

--- a/src/core/scraper/types.ts
+++ b/src/core/scraper/types.ts
@@ -85,7 +85,8 @@ export interface WindrunStaticAbility {
   valveId: number
   englishName: string
   shortName: string
-  ownerHeroId: number
+  /** Null for brand-new abilities Windrun hasn't linked yet (7.39 additions shipped this way) */
+  ownerHeroId: number | null
   hasScepter: boolean
   hasShard: boolean
   isUltimate?: boolean

--- a/src/main/ipc/ml-handlers.ts
+++ b/src/main/ipc/ml-handlers.ts
@@ -221,10 +221,14 @@ export function registerMlHandlers(
           }
         }
 
+        // DB ability names = classes still in the draft pool. Model classes
+        // outside this list (removed abilities kept in the model in case they
+        // return) are masked and can never be predicted.
         const result = await mlService.scan(
           screenshotBuffer,
           layout,
           data.isInitialScan,
+          dbService.abilities.getAllNames(),
         )
 
         appStore.setState({ mlStatus: 'ready' })

--- a/src/main/services/ml-service.ts
+++ b/src/main/services/ml-service.ts
@@ -36,10 +36,16 @@ const logger = log.scope('ml-service')
 
 export interface MlService {
   initialize(): Promise<void>
+  /**
+   * @param activeClassNames Ability internal names currently in the DB. Model
+   * classes outside this list (removed-from-pool abilities) are masked and can
+   * never be predicted. Omitted/empty → no masking.
+   */
   scan(
     screenshotBuffer: Buffer,
     layout: ResolutionLayout,
     isInitialScan: boolean,
+    activeClassNames?: string[],
   ): Promise<MlWorkerSuccessResponse>
   terminate(): Promise<void>
   isReady(): boolean
@@ -171,6 +177,7 @@ export function createMlService(): MlService {
     screenshotBuffer: Buffer,
     layout: ResolutionLayout,
     isInitialScan: boolean,
+    activeClassNames?: string[],
   ): Promise<MlWorkerSuccessResponse> {
     if (!worker || !ready) {
       throw new Error('ML Worker not ready')
@@ -210,6 +217,7 @@ export function createMlService(): MlService {
           layout,
           confidenceThreshold: ML_CONFIDENCE_THRESHOLD,
           isInitialScan,
+          activeClassNames,
         },
       }
 

--- a/src/main/workers/ml-worker.ts
+++ b/src/main/workers/ml-worker.ts
@@ -17,8 +17,9 @@ import type { ClassifierResult } from '@core/ml/classifier'
 // Message protocol:
 // - Main → { type: 'init', payload: { modelPath, classNamesPath, useDirectML } }
 //   → Worker replies { status: 'ready', executionProvider } or { status: 'error', type: 'init-error' }
-// - Main → { type: 'scan', payload: { screenshotBuffer, layout, confidenceThreshold, isInitialScan } }
-//   → Worker replies { status: 'success', results } or { status: 'error' }
+// - Main → { type: 'scan', payload: { screenshotBuffer, layout, confidenceThreshold, isInitialScan,
+//   activeClassNames? } } → Worker replies { status: 'success', results } or { status: 'error' }
+//   activeClassNames (DB ability names) masks model classes for removed-from-pool abilities.
 // - Main → { type: 'dispose' } → Worker releases ONNX session
 //
 // Scan pipeline: receive screenshot buffer → extract slot images (sharp crop+resize to 96x96) →
@@ -85,6 +86,7 @@ async function handleScan(payload: {
   layout: ResolutionLayout
   confidenceThreshold: number
   isInitialScan: boolean
+  activeClassNames?: string[]
 }): Promise<void> {
   if (!classifier.isReady()) {
     throw new Error('ML Worker not initialized')
@@ -95,18 +97,30 @@ async function handleScan(payload: {
     layout: coords,
     confidenceThreshold,
     isInitialScan,
+    activeClassNames,
   } = payload
   const buffer = Buffer.from(screenshotBuffer)
+
+  const activeSet =
+    activeClassNames && activeClassNames.length > 0
+      ? new Set(activeClassNames)
+      : undefined
 
   let results: InitialScanResults | ScanResult[]
 
   if (isInitialScan) {
-    results = await performInitialScan(buffer, coords, confidenceThreshold)
+    results = await performInitialScan(
+      buffer,
+      coords,
+      confidenceThreshold,
+      activeSet,
+    )
   } else {
     results = await performSelectedAbilitiesScan(
       buffer,
       coords,
       confidenceThreshold,
+      activeSet,
     )
   }
 
@@ -126,17 +140,20 @@ async function performInitialScan(
   screenshotBuffer: Buffer,
   coords: ResolutionLayout,
   confidenceThreshold: number,
+  activeClassNames?: ReadonlySet<string>,
 ): Promise<InitialScanResults> {
   const [ultimates, standard] = await Promise.all([
     identifySlots(
       coords.ultimate_slots_coords,
       screenshotBuffer,
       confidenceThreshold,
+      activeClassNames,
     ),
     identifySlots(
       coords.standard_slots_coords,
       screenshotBuffer,
       confidenceThreshold,
+      activeClassNames,
     ),
   ])
 
@@ -156,6 +173,7 @@ async function performSelectedAbilitiesScan(
   screenshotBuffer: Buffer,
   coords: ResolutionLayout,
   confidenceThreshold: number,
+  activeClassNames?: ReadonlySet<string>,
 ): Promise<ScanResult[]> {
   const selectedCoords = coords.selected_abilities_coords
   if (!selectedCoords || selectedCoords.length === 0) return []
@@ -167,7 +185,12 @@ async function performSelectedAbilitiesScan(
     height: params?.height ?? c.height,
   }))
 
-  return identifySlots(slotsToScan, screenshotBuffer, confidenceThreshold)
+  return identifySlots(
+    slotsToScan,
+    screenshotBuffer,
+    confidenceThreshold,
+    activeClassNames,
+  )
 }
 
 // @DEV-GUIDE: Core ML pipeline for a batch of slots. preprocessBatch crops each slot from the
@@ -177,6 +200,7 @@ async function identifySlots(
   slots: SlotCoordinate[],
   screenshotBuffer: Buffer,
   confidenceThreshold: number,
+  activeClassNames?: ReadonlySet<string>,
 ): Promise<ScanResult[]> {
   if (slots.length === 0) return []
 
@@ -190,6 +214,7 @@ async function identifySlots(
     batch,
     validIndices.length,
     confidenceThreshold,
+    activeClassNames,
   )
 
   // Initialize all results to defaults

--- a/src/shared/types/ml.ts
+++ b/src/shared/types/ml.ts
@@ -18,6 +18,13 @@ export interface MlWorkerScanRequest {
     layout: ResolutionLayout
     confidenceThreshold: number
     isInitialScan: boolean
+    /**
+     * Ability internal names currently in the DB (= still in the draft pool).
+     * Model classes outside this list are masked during classification, so
+     * removed-from-pool abilities kept in the model are never predicted.
+     * Omitted/empty → no masking.
+     */
+    activeClassNames?: string[]
   }
 }
 

--- a/tests/unit/core/database/ability-repository.test.ts
+++ b/tests/unit/core/database/ability-repository.test.ts
@@ -192,6 +192,52 @@ describe('AbilityRepository.applyLiquipediaMeta', () => {
   })
 })
 
+// Separate DB instance: these tests mutate ability_order/is_ultimate
+describe('AbilityRepository.setSlotMetadata', () => {
+  let testDb: TestDb
+  let repo: AbilityRepository
+
+  beforeEach(async () => {
+    testDb = await createTestDb()
+    seedTestData(testDb.db)
+    repo = createAbilityRepository(testDb.db)
+  })
+
+  afterEach(() => {
+    testDb.close()
+  })
+
+  it('forces ability_order and is_ultimate by internal name', () => {
+    const applied = repo.setSlotMetadata([
+      { name: 'antimage_mana_break', abilityOrder: 3, isUltimate: false },
+      { name: 'antimage_mana_void', abilityOrder: 0, isUltimate: true },
+    ])
+
+    expect(applied).toBe(2)
+    const details = repo.getDetails(['antimage_mana_break', 'antimage_mana_void'])
+    expect(details.get('antimage_mana_break')!.abilityOrder).toBe(3)
+    expect(details.get('antimage_mana_void')!.abilityOrder).toBe(0)
+    expect(details.get('antimage_mana_void')!.isUltimate).toBe(true)
+  })
+
+  it('overrides even rows that already hold a (wrong) value', () => {
+    // Unlike Liquipedia candidates, overrides are authoritative — they must
+    // correct rows like juggernaut_healing_ward that carry stale slot data
+    repo.setSlotMetadata([{ name: 'antimage_blink', abilityOrder: 1, isUltimate: false }])
+    const blink = repo.getDetails(['antimage_blink']).get('antimage_blink')
+    expect(blink!.abilityOrder).toBe(1) // seed had 2
+  })
+
+  it('counts only names that exist and handles empty input', () => {
+    const applied = repo.setSlotMetadata([
+      { name: 'antimage_mana_break', abilityOrder: 1, isUltimate: false },
+      { name: 'no_such_ability', abilityOrder: 2, isUltimate: false },
+    ])
+    expect(applied).toBe(1)
+    expect(repo.setSlotMetadata([])).toBe(0)
+  })
+})
+
 // Separate DB instance: these tests delete rows and would corrupt the shared fixture above
 describe('AbilityRepository.deleteAbilitiesNotIn', () => {
   let testDb: TestDb

--- a/tests/unit/core/ml/onnx-classifier.test.ts
+++ b/tests/unit/core/ml/onnx-classifier.test.ts
@@ -247,6 +247,109 @@ describe('OnnxClassifier', () => {
         classifier.classify(new Float32Array(96 * 96 * 3), 1, 0.9),
       ).rejects.toThrow('Classifier not initialized')
     })
+
+    describe('class masking (activeClassNames)', () => {
+      it('never predicts a masked class — next-best active class wins', async () => {
+        const classifier = await createInitializedClassifier()
+
+        // Masked class 42 has the top probability; active class 7 is runner-up
+        const output = makeOutputData(1, 524, [{ index: 42, confidence: 0.95 }])
+        output[7] = 0.93
+        mockRun.mockResolvedValueOnce({ Identity: { data: output } })
+
+        const active = new Set(makeClassNames(524))
+        active.delete('ability_42')
+
+        const results = await classifier.classify(
+          new Float32Array(96 * 96 * 3),
+          1,
+          0.9,
+          active,
+        )
+
+        expect(results[0].name).toBe('ability_7')
+        expect(results[0].confidence).toBeCloseTo(0.93)
+        expect(results[0].classIndex).toBe(7)
+      })
+
+      it('returns null when the surviving best is below the threshold', async () => {
+        const classifier = await createInitializedClassifier()
+
+        const output = makeOutputData(1, 524, [{ index: 42, confidence: 0.95 }])
+        output[7] = 0.6
+        mockRun.mockResolvedValueOnce({ Identity: { data: output } })
+
+        const active = new Set(makeClassNames(524))
+        active.delete('ability_42')
+
+        const results = await classifier.classify(
+          new Float32Array(96 * 96 * 3),
+          1,
+          0.9,
+          active,
+        )
+
+        expect(results[0].name).toBeNull()
+        expect(results[0].confidence).toBeCloseTo(0.6)
+      })
+
+      it('does not mask when the active set is empty', async () => {
+        const classifier = await createInitializedClassifier()
+
+        const output = makeOutputData(1, 524, [{ index: 42, confidence: 0.95 }])
+        mockRun.mockResolvedValueOnce({ Identity: { data: output } })
+
+        const results = await classifier.classify(
+          new Float32Array(96 * 96 * 3),
+          1,
+          0.9,
+          new Set<string>(),
+        )
+
+        expect(results[0].name).toBe('ability_42')
+      })
+
+      it('falls back to unmasked when the set would exclude every class', async () => {
+        const classifier = await createInitializedClassifier()
+
+        const output = makeOutputData(1, 524, [{ index: 42, confidence: 0.95 }])
+        mockRun.mockResolvedValueOnce({ Identity: { data: output } })
+
+        // Disjoint naming (e.g. corrupt DB) must not blind the scanner
+        const results = await classifier.classify(
+          new Float32Array(96 * 96 * 3),
+          1,
+          0.9,
+          new Set(['totally_unrelated_name']),
+        )
+
+        expect(results[0].name).toBe('ability_42')
+      })
+
+      it('masks independently for each image in a batch', async () => {
+        const classifier = await createInitializedClassifier()
+
+        const output = makeOutputData(2, 524, [
+          { index: 10, confidence: 0.99 },
+          { index: 200, confidence: 0.95 },
+        ])
+        output[524 + 300] = 0.91
+        mockRun.mockResolvedValueOnce({ Identity: { data: output } })
+
+        const active = new Set(makeClassNames(524))
+        active.delete('ability_200')
+
+        const results = await classifier.classify(
+          new Float32Array(2 * 96 * 96 * 3),
+          2,
+          0.9,
+          active,
+        )
+
+        expect(results[0].name).toBe('ability_10')
+        expect(results[1].name).toBe('ability_300')
+      })
+    })
   })
 
   describe('dispose', () => {

--- a/tests/unit/core/scraper/data-transformer.test.ts
+++ b/tests/unit/core/scraper/data-transformer.test.ts
@@ -144,6 +144,55 @@ describe('transformAbilitiesAndHeroes', () => {
     expect(heroData).toHaveLength(0)
     expect(abilityData).toHaveLength(0)
   })
+
+  it('derives the hero from the shortName prefix when ownerHeroId is null', () => {
+    // 7.39-era additions shipped by Windrun with ownerHeroId: null
+    const orphanAbility: WindrunStaticAbility = {
+      valveId: 1752,
+      englishName: "Wyrm's Wrath",
+      shortName: 'dragon_knight_wyrms_wrath',
+      ownerHeroId: null,
+      hasScepter: false,
+      hasShard: false,
+    }
+    const lookup = buildAbilityLookup([...staticAbilitiesArray, orphanAbility])
+    const heroesWithDk: Record<string, WindrunStaticHero> = {
+      ...staticHeroes,
+      '49': { id: 49, englishName: 'Dragon Knight', shortName: 'dragonknight' },
+      // A hero whose name is a prefix of another's must not steal the match
+      '90': { id: 90, englishName: 'Dragon', shortName: 'dragon' },
+    }
+    const stats: WindrunAbilityStat[] = [
+      { abilityId: 1752, numPicks: 100, avgPickPosition: 3, wins: 50, ownerHero: 0, winrate: 0.5, pickRate: 0.3 },
+    ]
+
+    const { abilityData } = transformAbilitiesAndHeroes(stats, [], lookup, heroesWithDk)
+
+    expect(abilityData).toHaveLength(1)
+    expect(abilityData[0].heroName).toBe('dragonknight')
+    expect(abilityData[0].heroId).toBe(49)
+  })
+
+  it('leaves heroName null when no hero prefix matches', () => {
+    const orphanAbility: WindrunStaticAbility = {
+      valveId: 1800,
+      englishName: 'Mystery',
+      shortName: 'unknown_hero_mystery',
+      ownerHeroId: null,
+      hasScepter: false,
+      hasShard: false,
+    }
+    const lookup = buildAbilityLookup([orphanAbility])
+    const stats: WindrunAbilityStat[] = [
+      { abilityId: 1800, numPicks: 10, avgPickPosition: 1, wins: 5, ownerHero: 0, winrate: 0.5, pickRate: 0.1 },
+    ]
+
+    const { abilityData } = transformAbilitiesAndHeroes(stats, [], lookup, staticHeroes)
+
+    expect(abilityData).toHaveLength(1)
+    expect(abilityData[0].heroName).toBeNull()
+    expect(abilityData[0].heroId).toBeNull()
+  })
 })
 
 // ── transformPairs ──────────────────────────────────────────────────────────

--- a/tests/unit/core/scraper/liquipedia-scraper.test.ts
+++ b/tests/unit/core/scraper/liquipedia-scraper.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { parseAbilitiesFromHtml } from '@core/scraper/liquipedia-scraper'
+import {
+  parseAbilitiesFromHtml,
+  heroNameToPageTitle,
+} from '@core/scraper/liquipedia-scraper'
 
 // Fixture mirrors the real structure of Liquipedia hero pages (verified against the
 // live Spectre page): spellcard IDs are DISPLAY names, hotkeys include non-R ultimates
@@ -80,5 +83,35 @@ describe('parseAbilitiesFromHtml', () => {
 
   it('returns empty array for HTML without spellcards', () => {
     expect(parseAbilitiesFromHtml('<div><p>No abilities here</p></div>')).toEqual([])
+  })
+})
+
+describe('heroNameToPageTitle', () => {
+  it('preserves natural casing of display-name-derived page names', () => {
+    // Title-casing these produced real page misses (Queen_Of_Pain → 0 abilities)
+    expect(heroNameToPageTitle('Queen_of_Pain')).toBe('Queen_of_Pain')
+    expect(heroNameToPageTitle('Keeper_of_the_Light')).toBe('Keeper_of_the_Light')
+    expect(heroNameToPageTitle('Death_Prophet')).toBe('Death_Prophet')
+  })
+
+  it('maps Outworld Devourer to the Liquipedia page name Outworld_Destroyer', () => {
+    expect(heroNameToPageTitle('Outworld_Devourer')).toBe('Outworld_Destroyer')
+    expect(heroNameToPageTitle('outworld_destroyer')).toBe('Outworld_Destroyer')
+  })
+
+  it('matches overrides from display names with punctuation', () => {
+    expect(heroNameToPageTitle('Anti-Mage')).toBe('Anti-Mage')
+    expect(heroNameToPageTitle("Nature's_Prophet")).toBe("Nature's_Prophet")
+  })
+
+  it('matches overrides from internal snake_case names', () => {
+    expect(heroNameToPageTitle('anti_mage')).toBe('Anti-Mage')
+    expect(heroNameToPageTitle('queen_of_pain')).toBe('Queen_of_Pain')
+    expect(heroNameToPageTitle('natures_prophet')).toBe("Nature's_Prophet")
+  })
+
+  it('title-cases plain internal snake_case names word by word', () => {
+    expect(heroNameToPageTitle('ursa')).toBe('Ursa')
+    expect(heroNameToPageTitle('death_prophet')).toBe('Death_Prophet')
   })
 })

--- a/tests/unit/core/scraper/orchestrator.test.ts
+++ b/tests/unit/core/scraper/orchestrator.test.ts
@@ -84,6 +84,7 @@ function createMockDeps(apiClient?: WindrunApiClient): ScraperDeps {
       getNameToIdMap: vi.fn().mockReturnValue(new Map([['ursa_fury_swipes', 100]])),
       getAllNames: vi.fn().mockReturnValue(['ursa_fury_swipes']),
       applyLiquipediaMeta: vi.fn().mockReturnValue(1),
+      setSlotMetadata: vi.fn().mockReturnValue(0),
       getAll: vi.fn().mockReturnValue([]),
       getById: vi.fn(),
       getByName: vi.fn(),
@@ -162,6 +163,25 @@ describe('performFullScrape', () => {
 
     expect(deps.abilities.deleteAbilitiesNotIn).toHaveBeenCalledOnce()
     expect(deps.abilities.deleteAbilitiesNotIn).toHaveBeenCalledWith(['ursa_fury_swipes'])
+  })
+
+  it('applies the hand-curated slot metadata overrides after the prune', async () => {
+    await performFullScrape(deps, onProgress)
+
+    expect(deps.abilities.setSlotMetadata).toHaveBeenCalledOnce()
+    const entries = (deps.abilities.setSlotMetadata as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as Array<{ name: string; abilityOrder: number; isUltimate: boolean }>
+    // Spot-check the user-verified corrections ride along with every scrape
+    expect(entries).toContainEqual({
+      name: 'juggernaut_healing_ward',
+      abilityOrder: 2,
+      isUltimate: false,
+    })
+    expect(entries).toContainEqual({
+      name: 'nevermore_dark_lord',
+      abilityOrder: 3,
+      isUltimate: false,
+    })
   })
 
   it('reports pruned stale abilities via progress', async () => {
@@ -288,6 +308,7 @@ describe('performLiquipediaEnrichment', () => {
     const deps: LiquipediaDeps = {
       abilities: {
         applyLiquipediaMeta,
+        setSlotMetadata: vi.fn().mockReturnValue(0),
       } as unknown as LiquipediaDeps['abilities'],
       persist: vi.fn(),
       enrichFromLiquipedia: vi.fn().mockResolvedValue([
@@ -309,6 +330,8 @@ describe('performLiquipediaEnrichment', () => {
     const result = await performLiquipediaEnrichment(deps, ['Drow Ranger'], onProgress)
 
     expect(result.success).toBe(true)
+    // Manual slot overrides must win over Liquipedia — re-applied after the updates
+    expect(deps.abilities.setSlotMetadata).toHaveBeenCalledOnce()
     // Page names ("Drow_Ranger") must be translated back to DB display names ("Drow Ranger")
     expect(applyLiquipediaMeta).toHaveBeenCalledWith([
       {

--- a/tests/unit/main/services/ml-service.test.ts
+++ b/tests/unit/main/services/ml-service.test.ts
@@ -201,6 +201,34 @@ describe('MlService', () => {
       expect(response.isInitialScan).toBe(true)
     })
 
+    it('forwards activeClassNames to the worker for class masking', async () => {
+      const service = await createReadyService()
+
+      const scanPromise = service.scan(
+        Buffer.from('screenshot'),
+        {} as never,
+        true,
+        ['ursa_fury_swipes', 'sniper_shrapnel'],
+      )
+
+      expect(mockWorkerInstance.postMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          type: 'scan',
+          payload: expect.objectContaining({
+            activeClassNames: ['ursa_fury_swipes', 'sniper_shrapnel'],
+          }),
+        }),
+        expect.any(Array),
+      )
+
+      mockWorkerInstance.emit('message', {
+        status: 'success',
+        results: [],
+        isInitialScan: true,
+      })
+      await scanPromise
+    })
+
     it('rejects on scan error', async () => {
       const service = await createReadyService()
 


### PR DESCRIPTION
## What

**Removed-from-pool abilities are now masked at inference instead of deleted from the model.** The DB (post-prune) is the source of truth for "still in the pool": on every scan the DB's ability names are passed into the ML worker, and the classifier skips non-active classes during argmax. A removed class can never be predicted — the next-best active class wins (key for renames with identical art / the twin problem), or the slot falls below the 0.9 threshold and renders Unknown. An ability returning to the pool is re-inserted by the Windrun scrape and unmasks automatically; the model keeps all trained classes.

- Guards: empty or fully disjoint active set disables masking rather than blinding the scanner.
- Defense in depth: `scan-processor` now renders predicted-but-not-in-DB names as Unknown — previously they showed the raw internal name with a fake neutral 0.5 score (eligible for top-tier suggestions) and broke hero identification for that row.

**Scraper repairs for the broken slot rows** (5 rows: 3 without `hero_id`, 2 without `ability_order`, plus 2 stale wrong values):

- `data-transformer`: derive the owner hero from the ability shortName prefix when Windrun ships `ownerHeroId: null` (verified against the live API for the 7.39 additions: `dragon_knight_wyrms_wrath`, `venomancer_snakebite`, `tinker_deploy_turrets`).
- New `SLOT_METADATA_OVERRIDES` (hand-curated, in-game-verified) applied after every Windrun scrape and re-applied after Liquipedia enrichment — authoritative over both sources. Seeds: `juggernaut_healing_ward=2`, `nevermore_frenzy=2`, `nevermore_dark_lord=3`, `phantom_assassin_immaterial=3`, `wyrms_wrath=3`, `snakebite=2`, `deploy_turrets=3`. Invoker/Kez/Jakiro multi-candidate slots intentionally untouched.
- Liquipedia page-title fix: title-casing produced real misses (`Queen_Of_Pain`, `Keeper_Of_The_Light` → 0 abilities; 177 updates silently dropped last run) and the override table was dead code (keyed on internal names, receiving display names). Natural casing is preserved, override keys are normalized, and `Outworld Devourer → Outworld_Destroyer` is mapped.

## Post-merge

Run "Update Windrun Data" in a dev build to heal the live DB (no Liquipedia run needed), then `refresh_db.py` + `validate_model.py` in the gather-script repo, and copy the healed DB into `resources/dota_ad_data.db` before the next release.

## Testing

- New unit tests: classifier masking (next-best wins, threshold, empty/disjoint fallback, per-batch), hero-prefix fallback, `setSlotMetadata`, override application in both scrape flows, page-title casing/overrides.
- `npm test`: 416/416 passing; `tsc --noEmit` clean; ESLint: no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)