### PR TITLE
Per-class confidence overrides for known hard classes

### DIFF
--- a/src/core/ml/onnx-classifier.ts
+++ b/src/core/ml/onnx-classifier.ts
@@ -1,6 +1,6 @@
 import * as ort from 'onnxruntime-node'
 import { readFile } from 'fs/promises'
-import { MODEL_INPUT_SIZE } from '@shared/constants/thresholds'
+import { MODEL_INPUT_SIZE, ML_CLASS_THRESHOLD_OVERRIDES } from '@shared/constants/thresholds'
 import type { ClassifierConfig, ClassifierResult, ImageClassifier } from './classifier'
 
 // @DEV-GUIDE: ONNX Runtime inference wrapper for ability icon classification.
@@ -11,7 +11,9 @@ import type { ClassifierConfig, ClassifierResult, ImageClassifier } from './clas
 // config, not a detected one.
 // Warmup inference runs on init to trigger JIT compilation.
 // classifyBatch() takes pre-processed float32 arrays and returns className + confidence pairs.
-// Returns null className if confidence < threshold (0.9).
+// Returns null className if confidence < threshold (0.9), unless the winning class
+// has a per-class override in ML_CLASS_THRESHOLD_OVERRIDES (known hard classes
+// like Crystal Nova that legitimately score below the global threshold).
 // Class masking: classify() optionally takes the set of active class names (the abilities
 // currently in the DB, i.e. still in the draft pool). Classes outside the set are skipped
 // during argmax, so a removed-from-pool ability that is still in the model can never be
@@ -119,11 +121,13 @@ export function createOnnxClassifier(): ImageClassifier {
           maxIndex = j
         }
       }
+      const predicted = maxIndex < classNames.length ? classNames[maxIndex] : null
+      const effectiveThreshold =
+        predicted !== null
+          ? (ML_CLASS_THRESHOLD_OVERRIDES[predicted] ?? confidenceThreshold)
+          : confidenceThreshold
       results.push({
-        name:
-          maxProb >= confidenceThreshold && maxIndex < classNames.length
-            ? classNames[maxIndex]
-            : null,
+        name: predicted !== null && maxProb >= effectiveThreshold ? predicted : null,
         confidence: maxProb,
         classIndex: maxIndex,
       })

--- a/src/shared/constants/thresholds.ts
+++ b/src/shared/constants/thresholds.ts
@@ -1,5 +1,13 @@
 // ML Configuration
 export const ML_CONFIDENCE_THRESHOLD = 0.9
+
+// Per-class confidence overrides for known hard classes: the class is accepted
+// when it wins the argmax at or above ITS threshold, even below the global one.
+// Crystal Nova consistently scores 0.55-0.9 on live boards while every other
+// class sits at 0.95+, so a nova argmax above 0.5 is virtually always correct.
+export const ML_CLASS_THRESHOLD_OVERRIDES: Readonly<Record<string, number>> = {
+  crystal_maiden_crystal_nova: 0.5,
+}
 export const ML_MODEL_INIT_TIMEOUT = 30_000
 export const ML_PREDICTION_TIMEOUT = 10_000
 export const ML_WORKER_MAX_RESTART_ATTEMPTS = 3

--- a/tests/unit/core/ml/onnx-classifier.test.ts
+++ b/tests/unit/core/ml/onnx-classifier.test.ts
@@ -248,6 +248,56 @@ describe('OnnxClassifier', () => {
       ).rejects.toThrow('Classifier not initialized')
     })
 
+    describe('per-class threshold overrides', () => {
+      // crystal_maiden_crystal_nova has a 0.5 override in ML_CLASS_THRESHOLD_OVERRIDES
+      async function createClassifierWithNova() {
+        const names = makeClassNames(524)
+        names[42] = 'crystal_maiden_crystal_nova'
+        mockReadFile.mockResolvedValueOnce(JSON.stringify(names))
+        const classifier = createOnnxClassifier()
+        await classifier.initialize({
+          modelPath: '/path/to/model.onnx',
+          classNamesPath: '/path/to/class_names.json',
+          useDirectML: false,
+        })
+        return classifier
+      }
+
+      it('accepts an overridden class below the global threshold', async () => {
+        const classifier = await createClassifierWithNova()
+
+        const output = makeOutputData(1, 524, [{ index: 42, confidence: 0.55 }])
+        mockRun.mockResolvedValueOnce({ Identity: { data: output } })
+
+        const results = await classifier.classify(new Float32Array(96 * 96 * 3), 1, 0.9)
+
+        expect(results[0].name).toBe('crystal_maiden_crystal_nova')
+        expect(results[0].confidence).toBeCloseTo(0.55)
+      })
+
+      it('still rejects an overridden class below its own threshold', async () => {
+        const classifier = await createClassifierWithNova()
+
+        const output = makeOutputData(1, 524, [{ index: 42, confidence: 0.45 }])
+        mockRun.mockResolvedValueOnce({ Identity: { data: output } })
+
+        const results = await classifier.classify(new Float32Array(96 * 96 * 3), 1, 0.9)
+
+        expect(results[0].name).toBeNull()
+      })
+
+      it('does not relax the threshold for non-overridden classes', async () => {
+        const classifier = await createClassifierWithNova()
+
+        const output = makeOutputData(1, 524, [{ index: 7, confidence: 0.55 }])
+        mockRun.mockResolvedValueOnce({ Identity: { data: output } })
+
+        const results = await classifier.classify(new Float32Array(96 * 96 * 3), 1, 0.9)
+
+        expect(results[0].name).toBeNull()
+      })
+    })
+
     describe('class masking (activeClassNames)', () => {
       it('never predicts a masked class — next-best active class wins', async () => {
         const classifier = await createInitializedClassifier()


### PR DESCRIPTION
## Summary
- Crystal Nova consistently scores 0.55-0.9 on live draft boards while every other class sits at 0.95+, so it rendered as "Unknown Ability" under the global 0.9 threshold (both v2.4.0 and v2.5.0 models; verified against real-match feedback samples from 2026-07-28).
- Adds `ML_CLASS_THRESHOLD_OVERRIDES` in `thresholds.ts`: when the argmax winner has an entry, its own threshold applies instead of the global one. Current entries: `crystal_maiden_crystal_nova: 0.5`.
- Applied in `onnx-classifier.ts` at the argmax site; composes with active-class masking (the override applies to whichever class survives the mask). No other class is affected.

## Testing
- 3 new unit tests (override accepted at 0.55, rejected below 0.5, non-overridden classes unaffected).
- Full suite: 419/419 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
