### PR TITLE
feat(stream): polish — docs, e2e smoke, packaged static-root fix (phase 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,12 @@ src/
   renderer/
     control-panel/   Main application window (React SPA)
     overlay/         Game overlay window (transparent, click-through)
+    stream/          Streamer view board (served over local HTTP for OBS)
   shared/        Types and constants shared between processes
 ```
 
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for detailed technical documentation.
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for detailed technical documentation
+and [docs/STREAMER_VIEW.md](docs/STREAMER_VIEW.md) for the OBS/streaming setup guide.
 
 ## License
 

--- a/docs/STREAMER_VIEW.md
+++ b/docs/STREAMER_VIEW.md
@@ -1,0 +1,100 @@
+# Streamer View
+
+A locally hosted, tournament-style draft board for broadcasting Ability Draft games.
+The app serves a web page that re-renders the live draft with official ability icons,
+high contrast, and stat panels — designed to be used as an OBS browser source instead
+of (or on top of) the game's own draft screen.
+
+## Quick start (streamer)
+
+1. Open the **Streaming** page in the control panel and press **Start server**.
+2. Copy the board URL (default `http://localhost:58873/stream`).
+3. In OBS: *Sources → Add → Browser*, paste the URL, size **1920×1080**.
+4. In game, activate the overlay and scan the draft (**Ctrl+Shift+S**).
+   The board renders the pool; rescans (**Ctrl+Shift+R**) grey out picked abilities
+   and fill the player rows.
+
+Background modes via query parameter:
+
+| URL suffix | Background |
+|---|---|
+| *(none)* / `?bg=transparent` | Transparent (OBS composites it) |
+| `?bg=dark` | Solid dark panel |
+| `?bg=chroma` | `#00FF00` green screen |
+
+Recommended: press **Prefetch all icons** once (Streaming page) so every ability icon
+is cached locally before your first live draft.
+
+## What the board shows
+
+- **12 hero rows** — portrait + Q/W/E + ultimate tiles with winrates; top-tier picks
+  get a gold border; picked abilities grey out on rescan.
+- **Stat panels** — highest-winrate abilities still in the pool, strongest (OP) and
+  worst (trap) combinations available, computed from the app's Windrun dataset.
+- **10 player rows** (Radiant / Dire) — picked abilities and a computed **draft score**
+  per player (mean normalized winrate + pair-synergy lift; confidence grows with pick
+  count).
+- Player names appear when GSI is connected (see below).
+
+## Game State Integration (GSI)
+
+GSI lets Dota itself send player names, game phase, and clock to the board. It does
+**not** carry the draft pool or picks — the ML scan remains the source for those.
+
+Setup (Streaming page → GSI card):
+
+1. **Install config file** — the app locates your Dota installation (Steam registry +
+   library folders) and writes
+   `game/dota/cfg/gamestate_integration/gamestate_integration_adplus.cfg`.
+   Use **Browse…** if detection fails.
+2. **Restart Dota 2.** The card's badge turns *Connected* once payloads arrive.
+
+Caveats:
+
+- The cfg pins the server **port** — reinstall it after changing the port.
+- All 10 player names are only available while **spectating/casting**. When playing,
+  Dota reports only your own identity.
+
+## Experimental: automatic draft tracking
+
+Off by default (Streaming page → *Auto draft tracking*). When enabled, during the
+draft the app rescans every 5 seconds and attributes each ability that left the pool
+to the player whose turn it was (turn clock anchored on GSI's hero-selection
+transition). This produces an ordered, attributed pick feed on the stream board.
+
+Things to know before enabling:
+
+- Your **mouse cursor briefly jumps** to the screen corner during each automatic
+  capture (hover tooltips would contaminate the screenshot). It never does this
+  during **your own** pick turn — automatic scans are suppressed then.
+- When playing (not spectating), select **My Spot** in the overlay first; without a
+  known slot the tracker stays idle by design.
+- The initial pool scan (**Ctrl+Shift+S**) is still manual.
+- Turns where no ability left the pool are recorded as *model selection* markers —
+  hero-model pick recognition is planned future work.
+- The Ability Draft turn timings used by the clock are still being validated against
+  real lobbies; expect attribution quirks (they are logged, and the board's snapshot
+  view is unaffected).
+
+## Architecture notes (maintainers)
+
+- Server: `src/main/services/stream-server-service.ts` — plain Node `http`, bound to
+  `127.0.0.1` only. Routes: static SPA (from `out/renderer`, asar-aware `readFile`),
+  `GET /events` (SSE, versioned full-state envelopes), `GET /icons/*`
+  (`icon-cache-service`, Valve CDN download-through cache in `userData/stream-icons`),
+  `POST /gsi` (parser in `src/core/gsi/`).
+- Board assembly is pure: `src/core/domain/stream-board.ts` builds the grid from the
+  draft's *initial* scan payload (rescans subtract picked abilities from pool arrays)
+  and the latest payload for picks/panels.
+- The SPA (`src/renderer/stream/`) has **no preload and no electron API** — it runs in
+  OBS's Chromium; its only I/O is `EventSource('/events')` and `<img>` tags.
+- The wire protocol is versioned (`StreamEnvelope.v`) for future consumers — e.g. a
+  Twitch extension backend.
+- Dev mode: the SPA lives on the electron-vite dev server, so `/stream` redirects
+  there with `?api=<server origin>` for the SSE connection.
+
+## Planned (not yet built)
+
+- Hero-model pick recognition (the `modelSelectionMarker` events mark the hook).
+- Twitch extension letting viewers browse pool abilities themselves.
+- Caster-triggered short clips explaining broken/bugged abilities during the draft.

--- a/src/main/services/stream-server-service.ts
+++ b/src/main/services/stream-server-service.ts
@@ -98,7 +98,12 @@ export function createStreamServerService(
   let gsiBroadcastTimer: NodeJS.Timeout | null = null
   const gsiListeners: Array<(snapshot: GsiSnapshot) => void> = []
 
-  const staticRoot = join(app.getAppPath(), 'out', 'renderer')
+  // Same path convention as window-manager's loadWindowContent: resolve renderer
+  // output relative to the compiled main bundle (out/main -> out/renderer). Works in
+  // dev-build launches AND packaged (app.asar/out/main -> asar-aware readFile).
+  // app.getAppPath() is NOT reliable here (electron <file.js> resolves it to the
+  // default_app wrapper).
+  const staticRoot = join(__dirname, '..', 'renderer')
 
   function gsiConnected(): boolean {
     return gsiLastAt !== null && Date.now() - gsiLastAt < GSI_STALE_MS

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -14,3 +14,47 @@ test('app launches and shows control panel', async () => {
 
   await app.close()
 })
+
+test('stream server serves the board and SSE endpoint', async () => {
+  const app = await electron.launch({
+    args: [resolve(__dirname, '../../out/main/index.js')],
+  })
+
+  const window = await app.firstWindow()
+  await window.waitForLoadState('domcontentloaded')
+
+  // Start the stream server through the same IPC surface the Streaming page uses
+  const startResult = await window.evaluate(async () => {
+    const api = (
+      window as unknown as {
+        electronApi: {
+          invoke: (channel: string, args?: unknown) => Promise<unknown>
+        }
+      }
+    ).electronApi
+    return api.invoke('stream:start', { port: 58873 })
+  })
+  expect(startResult).toMatchObject({ success: true })
+
+  // The board SPA is served from out/renderer
+  const pageResponse = await fetch('http://127.0.0.1:58873/stream')
+  expect(pageResponse.status).toBe(200)
+  const html = await pageResponse.text()
+  expect(html).toContain('Stream Board')
+
+  // SSE endpoint pushes a versioned state envelope on connect
+  const sseResponse = await fetch('http://127.0.0.1:58873/events', {
+    headers: { Accept: 'text/event-stream' },
+  })
+  expect(sseResponse.status).toBe(200)
+  expect(sseResponse.headers.get('content-type')).toContain('text/event-stream')
+  const reader = sseResponse.body?.getReader()
+  expect(reader).toBeDefined()
+  const { value } = await reader!.read()
+  const firstChunk = new TextDecoder().decode(value)
+  expect(firstChunk).toContain('"type":"state"')
+  expect(firstChunk).toContain('"phase":"waiting"')
+  await reader!.cancel()
+
+  await app.close()
+})


### PR DESCRIPTION
## What

Final phase of the Streamer View stack. **Stacked on #103.**

- **\`docs/STREAMER_VIEW.md\`** — streamer quick start (OBS browser source, \`?bg=\` modes, icon prefetch), GSI setup with the port/spectator caveats, experimental auto-tracking notes (cursor parking, My Spot requirement), and a maintainer architecture summary. Linked from the README.
- **Playwright smoke extension** — a second e2e test starts the stream server through the real \`stream:start\` IPC surface, then asserts the board page serves and the SSE endpoint pushes a versioned \`state\` envelope (\`phase: waiting\`). Runs in CI after build like the existing smoke.
- **Real bug fixed by that test**: the stream server resolved its static root via \`app.getAppPath()\`, which points at Electron's \`default_app\` wrapper when launched as \`electron <file.js>\` — every static request 404'd. Now resolves \`out/renderer\` relative to \`__dirname\`, the same convention \`window-manager\` uses (works in dev-build launches and packaged asar).

## Tests

Full suite 501 passing; both e2e smoke tests green locally after a fresh build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)