### PR TITLE
fix(stream): spectator auto-rescan, replay-safe draft sessions, GSI capture

### DIFF
--- a/src/core/gsi/parser.ts
+++ b/src/core/gsi/parser.ts
@@ -27,15 +27,22 @@ function slotIndexFromKey(key: string): number | null {
   return match ? parseInt(match[1], 10) : null
 }
 
-function parseTeamPlayers(team: unknown, into: GsiPlayer[]): void {
+function parseTeamPlayers(
+  team: unknown,
+  into: GsiPlayer[],
+  isDire: boolean,
+): void {
   const teamRecord = asRecord(team)
   if (!teamRecord) return
   for (const [key, value] of Object.entries(teamRecord)) {
-    const slotIndex = slotIndexFromKey(key)
+    const rawIndex = slotIndexFromKey(key)
     const player = asRecord(value)
-    if (slotIndex === null || !player) continue
+    if (rawIndex === null || !player) continue
     const name = asString(player['name'])
     if (!name) continue
+    // Some GSI versions key each team's block player0..player4, others use the
+    // global player0..player9 numbering. Normalize dire to global slots 5-9.
+    const slotIndex = isDire && rawIndex < 5 ? rawIndex + 5 : rawIndex
     into.push({
       slotIndex,
       name,
@@ -60,9 +67,9 @@ export function parseGsiPayload(json: unknown): GsiSnapshot {
     const team2 = playerBlock['team2']
     const team3 = playerBlock['team3']
     if (asRecord(team2) || asRecord(team3)) {
-      // Spectator mode: allplayers keyed player0..player9 across the two teams
-      parseTeamPlayers(team2, players)
-      parseTeamPlayers(team3, players)
+      // Spectator mode: allplayers split into team2 (radiant) / team3 (dire)
+      parseTeamPlayers(team2, players, false)
+      parseTeamPlayers(team3, players, true)
       players.sort((a, b) => a.slotIndex - b.slotIndex)
     } else {
       const name = asString(playerBlock['name'])
@@ -75,6 +82,7 @@ export function parseGsiPayload(json: unknown): GsiSnapshot {
   return {
     gamePhase: map ? asString(map['game_state']) : null,
     clockTime: map ? asNumber(map['clock_time']) : null,
+    matchId: map ? asString(map['matchid']) : null,
     players,
     localPlayer,
   }

--- a/src/core/gsi/types.ts
+++ b/src/core/gsi/types.ts
@@ -21,6 +21,8 @@ export interface GsiSnapshot {
   /** e.g. "DOTA_GAMERULES_STATE_HERO_SELECTION"; null when the map block is absent. */
   gamePhase: string | null
   clockTime: number | null
+  /** map.matchid — distinguishes a NEW draft from phase flapping (replay seeking). */
+  matchId: string | null
   /** Empty while playing (only spectators receive allplayers data). */
   players: GsiPlayer[]
   /** The local player when Dota reports one (playing, not spectating). */

--- a/src/main/services/auto-rescan-service.ts
+++ b/src/main/services/auto-rescan-service.ts
@@ -62,6 +62,7 @@ export function createAutoRescanService(
   let lastAttributedS = 0
   let nextSeq = 0
   let lastPhase: string | null = null
+  let draftMatchId: string | null = null
   let warnedNoSlot = false
 
   streamService.onGsiSnapshot((snapshot) => {
@@ -70,15 +71,31 @@ export function createAutoRescanService(
     lastPhase = snapshot.gamePhase
 
     if (snapshot.gamePhase === GSI_HERO_SELECTION_PHASE) {
+      // Replay seeking / directed camera makes game_state flap in and out of hero
+      // selection every few seconds. Only a DIFFERENT matchid (or the very first
+      // entry) is a new draft; re-entries keep the anchor and timeline.
+      const isSameDraft =
+        draftAnchorMs !== null &&
+        snapshot.matchId !== null &&
+        snapshot.matchId === draftMatchId
+      if (isSameDraft) {
+        logger.info('Re-entered hero selection (same match, keeping session)', {
+          matchId: snapshot.matchId,
+        })
+        return
+      }
       draftAnchorMs = Date.now()
+      draftMatchId = snapshot.matchId
       lastAttributedS = 0
       nextSeq = 0
       warnedNoSlot = false
       draftStore.getState().clearDraftTimeline()
-      logger.info('Draft started (GSI hero selection)', { prevPhase })
+      logger.info('Draft started (GSI hero selection)', {
+        prevPhase,
+        matchId: snapshot.matchId,
+      })
     } else if (prevPhase === GSI_HERO_SELECTION_PHASE) {
-      draftAnchorMs = null
-      logger.info('Draft ended (left hero selection)', {
+      logger.info('Left hero selection (session retained for possible re-entry)', {
         nextPhase: snapshot.gamePhase,
       })
     }
@@ -89,6 +106,15 @@ export function createAutoRescanService(
     return [...cache.ultimates, ...cache.standard]
       .map((slot) => slot.name)
       .filter((name): name is string => name !== null)
+  }
+
+  /** Pure spectator: allplayers present but no local player — there is no own turn. */
+  function isSpectating(snapshot: GsiSnapshot | null): boolean {
+    return (
+      snapshot !== null &&
+      snapshot.players.length > 0 &&
+      snapshot.localPlayer === null
+    )
   }
 
   function resolveUserSlot(snapshot: GsiSnapshot | null): number | null {
@@ -117,13 +143,15 @@ export function createAutoRescanService(
       // The pool grid is still the user's manual initial scan (Ctrl+Shift+S)
       if (poolNames().length === 0) return
 
-      const userSlot = resolveUserSlot(snapshot)
-      if (userSlot === null) {
+      // Spectators/casters have no pick turn to protect — scan without suppression.
+      // Only a PLAYING user with an unknown slot forces idle (cursor parking during
+      // their own pick would be hostile and we cannot tell when their turn is).
+      const spectating = isSpectating(snapshot)
+      const userSlot = spectating ? null : resolveUserSlot(snapshot)
+      if (!spectating && userSlot === null) {
         if (!warnedNoSlot) {
           warnedNoSlot = true
-          logger.warn(
-            'Auto-rescan idle: user slot unknown (select My Spot or spectate)',
-          )
+          logger.warn('Auto-rescan idle: playing with unknown slot — select My Spot')
         }
         return
       }
@@ -137,7 +165,7 @@ export function createAutoRescanService(
         return
       }
 
-      if (currentTurn?.playerIndex === userSlot) {
+      if (userSlot !== null && currentTurn?.playerIndex === userSlot) {
         // Suppressed: never park the cursor during the user's own pick
         return
       }

--- a/src/main/services/stream-server-service.ts
+++ b/src/main/services/stream-server-service.ts
@@ -97,6 +97,11 @@ export function createStreamServerService(
   let gsiStaleTimer: NodeJS.Timeout | null = null
   let gsiBroadcastTimer: NodeJS.Timeout | null = null
   const gsiListeners: Array<(snapshot: GsiSnapshot) => void> = []
+  // Raw-payload capture for empirical validation (slot ordering, phase names,
+  // AD turn timings): latest payload per game_state, overwritten, throttled.
+  const gsiCaptureDir = join(app.getPath('userData'), 'gsi-captures')
+  const gsiCaptureLastWrite = new Map<string, number>()
+  let gsiLastPlayersLog = ''
 
   // Same path convention as window-manager's loadWindowContent: resolve renderer
   // output relative to the compiled main bundle (out/main -> out/renderer). Works in
@@ -241,6 +246,33 @@ export function createStreamServerService(
     res.end(data)
   }
 
+  function captureGsiPayload(rawBody: string, phase: string | null): void {
+    const safePhase = (phase ?? 'unknown').replace(/[^A-Za-z0-9_]/g, '_')
+    const now = Date.now()
+    const lastWrite = gsiCaptureLastWrite.get(safePhase) ?? 0
+    if (now - lastWrite < 5_000) return
+    gsiCaptureLastWrite.set(safePhase, now)
+    void fs
+      .mkdir(gsiCaptureDir, { recursive: true })
+      .then(() => fs.writeFile(join(gsiCaptureDir, `${safePhase}.json`), rawBody))
+      .catch((error: unknown) => {
+        logger.warn('GSI capture write failed', {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      })
+  }
+
+  function logParsedPlayers(snapshot: GsiSnapshot): void {
+    if (snapshot.players.length === 0) return
+    const mapping = snapshot.players
+      .map((p) => `${p.slotIndex}:${p.name}`)
+      .join(', ')
+    if (mapping !== gsiLastPlayersLog) {
+      gsiLastPlayersLog = mapping
+      logger.info('GSI player slots', { mapping })
+    }
+  }
+
   function scheduleGsiBroadcast(): void {
     if (gsiBroadcastTimer) return
     gsiBroadcastTimer = setTimeout(() => {
@@ -274,10 +306,13 @@ export function createStreamServerService(
         return
       }
       try {
-        const json: unknown = JSON.parse(Buffer.concat(chunks).toString('utf-8'))
+        const rawBody = Buffer.concat(chunks).toString('utf-8')
+        const json: unknown = JSON.parse(rawBody)
         const wasConnected = gsiConnected()
         gsiSnapshot = parseGsiPayload(json)
         gsiLastAt = Date.now()
+        captureGsiPayload(rawBody, gsiSnapshot.gamePhase)
+        logParsedPlayers(gsiSnapshot)
         if (!wasConnected) {
           appStore.setState({ gsiConnected: true })
           logger.info('GSI connected')

--- a/tests/unit/core/gsi/parser.test.ts
+++ b/tests/unit/core/gsi/parser.test.ts
@@ -74,6 +74,26 @@ describe('parseGsiPayload', () => {
     expect(snapshot.clockTime).toBe(42)
   })
 
+  it('extracts the match id for draft-session identity', () => {
+    expect(parseGsiPayload(SPECTATOR_PAYLOAD).matchId).toBe('7000000001')
+    expect(parseGsiPayload({ map: {} }).matchId).toBeNull()
+  })
+
+  it('normalizes dire blocks keyed player0..player4 to global slots 5-9', () => {
+    const snapshot = parseGsiPayload({
+      player: {
+        team2: { player0: { name: 'R1' }, player4: { name: 'R5' } },
+        team3: { player0: { name: 'D1' }, player4: { name: 'D5' } },
+      },
+    })
+    expect(snapshot.players.map((p) => [p.slotIndex, p.name])).toEqual([
+      [0, 'R1'],
+      [4, 'R5'],
+      [5, 'D1'],
+      [9, 'D5'],
+    ])
+  })
+
   it('degrades gracefully on heartbeat payloads without map/player', () => {
     const snapshot = parseGsiPayload({
       provider: { name: 'Dota 2', appid: 570 },
@@ -81,6 +101,7 @@ describe('parseGsiPayload', () => {
     expect(snapshot).toEqual({
       gamePhase: null,
       clockTime: null,
+      matchId: null,
       players: [],
       localPlayer: null,
     })


### PR DESCRIPTION
## What

Fixes from the first real spectated-draft test (log + feedback-sample evidence):

1. **Auto-rescan never ran while spectating** — the log showed `Auto-rescan idle: user slot unknown`. A pure spectator (allplayers present, no local player) has no pick turn to protect, so the tick now proceeds **without suppression**; idle-on-unknown-slot applies only when actually playing.
2. **Replay/directed-camera seeking destroyed the draft session** — `game_state` flapped in/out of `HERO_SELECTION` every few seconds (visible in the log), resetting the turn-clock anchor and clearing the timeline each time. Sessions are now keyed by `map.matchid`: re-entering hero selection in the same match keeps the anchor and timeline.
3. **Player-name order** — parser now normalizes dire team blocks keyed `player0..player4` to global slots 5–9 (covers both observed GSI numbering schemes), and:
4. **Empirical capture added** — the server writes the latest raw GSI payload per game_state to `userData/gsi-captures/` (throttled, overwritten) and logs the parsed `slot → name` mapping whenever it changes. The next spectated draft gives us ground truth to finalize the slot mapping and the draft-clock timings.

Not addressed here (needs the capture / more data): the three low-confidence tiles in the 2560×1440 spectator-view scan — 45/48 recognized; the spectator UI shifts the board slightly vs the player-view layout presets.

## Tests

503 passing (2 new parser tests: matchid extraction, dire-block normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)