### PR TITLE
feat(stream): hero model pick identification via GSI

### DIFF
--- a/src/core/domain/stream-board.ts
+++ b/src/core/domain/stream-board.ts
@@ -59,6 +59,7 @@ const EMPTY_GSI: StreamGsiInfo = {
   gamePhase: null,
   clockTime: null,
   playerNames: [],
+  playerModels: [],
 }
 
 function toStreamSlot(
@@ -145,10 +146,15 @@ function buildPlayerRows(
           )
         : null
 
+    const gsiModel = gsi.playerModels[playerIndex] ?? null
+
     rows.push({
       playerIndex,
       team: playerIndex < PLAYER_COUNT / 2 ? 'radiant' : 'dire',
       playerName: gsi.playerNames[playerIndex] ?? null,
+      model: gsiModel
+        ? { ...gsiModel, portraitPath: heroIconPath(gsiModel.npcName) }
+        : null,
       picks,
       draftScore,
     })

--- a/src/core/gsi/parser.ts
+++ b/src/core/gsi/parser.ts
@@ -27,6 +27,22 @@ function slotIndexFromKey(key: string): number | null {
   return match ? parseInt(match[1], 10) : null
 }
 
+/** "npc_dota_hero_sand_king" -> "sand_king"; null for empty/absent names. */
+function heroNpcShortName(value: unknown): string | null {
+  const name = asString(value)
+  if (!name || !name.startsWith('npc_dota_hero_')) return null
+  return name.slice('npc_dota_hero_'.length)
+}
+
+/** Normalize a per-team block key to the global 0-9 slot numbering. */
+function globalSlotIndex(key: string, isDire: boolean): number | null {
+  const rawIndex = slotIndexFromKey(key)
+  if (rawIndex === null) return null
+  // Some GSI versions key each team's block player0..player4, others use the
+  // global player0..player9 numbering. Normalize dire to global slots 5-9.
+  return isDire && rawIndex < 5 ? rawIndex + 5 : rawIndex
+}
+
 function parseTeamPlayers(
   team: unknown,
   into: GsiPlayer[],
@@ -35,20 +51,33 @@ function parseTeamPlayers(
   const teamRecord = asRecord(team)
   if (!teamRecord) return
   for (const [key, value] of Object.entries(teamRecord)) {
-    const rawIndex = slotIndexFromKey(key)
+    const slotIndex = globalSlotIndex(key, isDire)
     const player = asRecord(value)
-    if (rawIndex === null || !player) continue
+    if (slotIndex === null || !player) continue
     const name = asString(player['name'])
     if (!name) continue
-    // Some GSI versions key each team's block player0..player4, others use the
-    // global player0..player9 numbering. Normalize dire to global slots 5-9.
-    const slotIndex = isDire && rawIndex < 5 ? rawIndex + 5 : rawIndex
     into.push({
       slotIndex,
       name,
       accountId: asString(player['accountid']),
+      heroNpcName: null,
     })
   }
+}
+
+/** Spectator hero block: { team2: { playerN: { name: "npc_dota_hero_x" } }, team3: ... } */
+function parseTeamHeroes(team: unknown, isDire: boolean): Map<number, string> {
+  const heroes = new Map<number, string>()
+  const teamRecord = asRecord(team)
+  if (!teamRecord) return heroes
+  for (const [key, value] of Object.entries(teamRecord)) {
+    const slotIndex = globalSlotIndex(key, isDire)
+    const hero = asRecord(value)
+    if (slotIndex === null || !hero) continue
+    const npcName = heroNpcShortName(hero['name'])
+    if (npcName) heroes.set(slotIndex, npcName)
+  }
+  return heroes
 }
 
 /**
@@ -63,6 +92,9 @@ export function parseGsiPayload(json: unknown): GsiSnapshot {
   const players: GsiPlayer[] = []
   let localPlayer: GsiSnapshot['localPlayer'] = null
 
+  const heroBlock = asRecord(root['hero'])
+  let localHeroNpcName: string | null = null
+
   if (playerBlock) {
     const team2 = playerBlock['team2']
     const team3 = playerBlock['team3']
@@ -71,11 +103,24 @@ export function parseGsiPayload(json: unknown): GsiSnapshot {
       parseTeamPlayers(team2, players, false)
       parseTeamPlayers(team3, players, true)
       players.sort((a, b) => a.slotIndex - b.slotIndex)
+
+      // Picked hero MODELS mirror the same team structure in the hero block
+      if (heroBlock) {
+        const heroBySlot = new Map([
+          ...parseTeamHeroes(heroBlock['team2'], false),
+          ...parseTeamHeroes(heroBlock['team3'], true),
+        ])
+        for (const player of players) {
+          player.heroNpcName = heroBySlot.get(player.slotIndex) ?? null
+        }
+      }
     } else {
       const name = asString(playerBlock['name'])
       if (name) {
         localPlayer = { name, accountId: asString(playerBlock['accountid']) }
       }
+      // Playing: the hero block is the local player's own model
+      localHeroNpcName = heroBlock ? heroNpcShortName(heroBlock['name']) : null
     }
   }
 
@@ -85,5 +130,6 @@ export function parseGsiPayload(json: unknown): GsiSnapshot {
     matchId: map ? asString(map['matchid']) : null,
     players,
     localPlayer,
+    localHeroNpcName,
   }
 }

--- a/src/core/gsi/types.ts
+++ b/src/core/gsi/types.ts
@@ -15,6 +15,8 @@ export interface GsiPlayer {
   slotIndex: number
   name: string
   accountId: string | null
+  /** Picked hero model as Valve npc short name (e.g. "sand_king"); null until picked. */
+  heroNpcName: string | null
 }
 
 export interface GsiSnapshot {
@@ -27,6 +29,8 @@ export interface GsiSnapshot {
   players: GsiPlayer[]
   /** The local player when Dota reports one (playing, not spectating). */
   localPlayer: { name: string; accountId: string | null } | null
+  /** The local player's picked hero model (playing only); npc short name. */
+  localHeroNpcName: string | null
 }
 
 export const GSI_HERO_SELECTION_PHASE = 'DOTA_GAMERULES_STATE_HERO_SELECTION'

--- a/src/main/services/stream-server-service.ts
+++ b/src/main/services/stream-server-service.ts
@@ -114,13 +114,34 @@ export function createStreamServerService(
     return gsiLastAt !== null && Date.now() - gsiLastAt < GSI_STALE_MS
   }
 
+  /** npc short name -> display name via the DB (Windrun short names are the npc
+   * name without underscores, e.g. sand_king -> sandking); title-case fallback. */
+  function heroDisplayName(npcName: string): string {
+    const dbHero = dbService.heroes
+      .getAll()
+      .find((h) => h.name === npcName.replace(/_/g, ''))
+    if (dbHero) return dbHero.displayName
+    return npcName
+      .split('_')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ')
+  }
+
   function gsiInfo(): StreamGsiInfo {
     const connected = gsiConnected()
     const playerNames: (string | null)[] = Array.from({ length: 10 }, () => null)
+    const playerModels: ({ npcName: string; displayName: string } | null)[] =
+      Array.from({ length: 10 }, () => null)
     if (gsiSnapshot) {
       for (const player of gsiSnapshot.players) {
         if (player.slotIndex >= 0 && player.slotIndex < 10) {
           playerNames[player.slotIndex] = player.name
+          if (player.heroNpcName) {
+            playerModels[player.slotIndex] = {
+              npcName: player.heroNpcName,
+              displayName: heroDisplayName(player.heroNpcName),
+            }
+          }
         }
       }
     }
@@ -129,6 +150,7 @@ export function createStreamServerService(
       gamePhase: connected ? (gsiSnapshot?.gamePhase ?? null) : null,
       clockTime: connected ? (gsiSnapshot?.clockTime ?? null) : null,
       playerNames,
+      playerModels,
     }
   }
 

--- a/src/renderer/stream/src/components/PlayerRows.tsx
+++ b/src/renderer/stream/src/components/PlayerRows.tsx
@@ -1,6 +1,22 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { StreamPlayerRow, StreamTeam } from '@shared/types/stream'
+import type { StreamPlayerModel, StreamPlayerRow, StreamTeam } from '@shared/types/stream'
 import { AbilityTile } from './AbilityTile'
+import { apiBase } from '../hooks/use-stream-state'
+
+function ModelPortrait({ model }: { model: StreamPlayerModel }) {
+  const [failed, setFailed] = useState(false)
+  if (failed) return null
+  return (
+    <img
+      className="player-model"
+      src={`${apiBase()}${model.portraitPath}`}
+      alt={model.displayName}
+      title={model.displayName}
+      onError={() => setFailed(true)}
+    />
+  )
+}
 
 function PlayerCard({ player }: { player: StreamPlayerRow }) {
   const { t } = useTranslation()
@@ -10,6 +26,7 @@ function PlayerCard({ player }: { player: StreamPlayerRow }) {
   return (
     <div className="player-card">
       <div className="player-head">
+        {player.model && <ModelPortrait model={player.model} />}
         <span className="player-name" title={name}>
           {name}
         </span>

--- a/src/renderer/stream/src/stream.css
+++ b/src/renderer/stream/src/stream.css
@@ -366,6 +366,14 @@ body,
   gap: 0.3rem;
 }
 
+.player-model {
+  height: 1.3rem;
+  width: 2.1rem;
+  object-fit: cover;
+  border-radius: 0.2rem;
+  flex-shrink: 0;
+}
+
 .player-name {
   font-size: 0.78rem;
   overflow: hidden;

--- a/src/shared/types/stream.ts
+++ b/src/shared/types/stream.ts
@@ -49,6 +49,15 @@ export interface StreamHeroRow {
 
 export type StreamTeam = 'radiant' | 'dire'
 
+/** A player's picked hero model (from GSI). */
+export interface StreamPlayerModel {
+  /** Valve npc short name (e.g. "sand_king") — also the CDN portrait key. */
+  npcName: string
+  displayName: string
+  /** Server-relative portrait path. */
+  portraitPath: string
+}
+
 /** One of the 10 player rows with their picked abilities. */
 export interface StreamPlayerRow {
   /** Player index 0–9 as scanned from selected-ability tiles (0–4 radiant, 5–9 dire). */
@@ -56,6 +65,8 @@ export interface StreamPlayerRow {
   team: StreamTeam
   /** From GSI when available; null until known. */
   playerName: string | null
+  /** Picked hero model from GSI (spectating); null until picked/unknown. */
+  model: StreamPlayerModel | null
   picks: StreamAbilitySlot[]
   draftScore: PlayerDraftScore | null
 }
@@ -104,6 +115,8 @@ export interface StreamGsiInfo {
   clockTime: number | null
   /** Player names by player index 0–9; empty or sparse until GSI reports them. */
   playerNames: (string | null)[]
+  /** Picked hero models by player index 0–9 (npcName + resolved display name). */
+  playerModels: ({ npcName: string; displayName: string } | null)[]
 }
 
 /** Full board snapshot — the only message payload v1 pushes. */

--- a/tests/unit/core/domain/stream-board.test.ts
+++ b/tests/unit/core/domain/stream-board.test.ts
@@ -206,6 +206,10 @@ describe('buildStreamBoardState', () => {
           gamePhase: 'DOTA_GAMERULES_STATE_HERO_SELECTION',
           clockTime: 42,
           playerNames: ['Alice', null, null, null, null, null, null, 'Bob', null, null],
+          playerModels: [
+            { npcName: 'sand_king', displayName: 'Sand King' },
+            null, null, null, null, null, null, null, null, null,
+          ],
         },
       }),
     )
@@ -215,6 +219,12 @@ describe('buildStreamBoardState', () => {
     expect(state.players[7].team).toBe('dire')
     expect(state.players[0].playerName).toBe('Alice')
     expect(state.players[7].playerName).toBe('Bob')
+    expect(state.players[0].model).toEqual({
+      npcName: 'sand_king',
+      displayName: 'Sand King',
+      portraitPath: '/icons/heroes/sand_king.png',
+    })
+    expect(state.players[1].model).toBeNull()
     expect(state.players[0].picks.map((p) => p.name)).toEqual(['pudge_rot'])
     expect(state.players[7].picks.map((p) => p.name)).toEqual(['hero1_slot1'])
     expect(state.players[1].picks).toEqual([])

--- a/tests/unit/core/gsi/parser.test.ts
+++ b/tests/unit/core/gsi/parser.test.ts
@@ -28,6 +28,15 @@ const SPECTATOR_PAYLOAD = {
       player9: { steamid: '76561198000000010', accountid: '40000010', name: 'Judy' },
     },
   },
+  hero: {
+    team2: {
+      player0: { facet: 0, id: 28, name: 'npc_dota_hero_slardar' },
+      player1: { facet: 0, id: 0, name: '' },
+    },
+    team3: {
+      player5: { facet: 0, id: 74, name: 'npc_dota_hero_sand_king' },
+    },
+  },
 }
 
 const PLAYING_PAYLOAD = {
@@ -45,6 +54,7 @@ const PLAYING_PAYLOAD = {
     activity: 'playing',
     kills: 0,
   },
+  hero: { facet: 0, id: 56, name: 'npc_dota_hero_clinkz' },
 }
 
 describe('parseGsiPayload', () => {
@@ -72,6 +82,37 @@ describe('parseGsiPayload', () => {
     })
     expect(snapshot.gamePhase).toBe('DOTA_GAMERULES_STATE_GAME_IN_PROGRESS')
     expect(snapshot.clockTime).toBe(42)
+  })
+
+  it('attaches spectator hero models to players by slot (empty names = unpicked)', () => {
+    const snapshot = parseGsiPayload(SPECTATOR_PAYLOAD)
+    const bySlot = new Map(snapshot.players.map((p) => [p.slotIndex, p.heroNpcName]))
+    expect(bySlot.get(0)).toBe('slardar')
+    expect(bySlot.get(1)).toBeNull()
+    expect(bySlot.get(5)).toBe('sand_king')
+    expect(bySlot.get(9)).toBeNull()
+    expect(snapshot.localHeroNpcName).toBeNull()
+  })
+
+  it('extracts the local hero model while playing', () => {
+    const snapshot = parseGsiPayload(PLAYING_PAYLOAD)
+    expect(snapshot.localHeroNpcName).toBe('clinkz')
+  })
+
+  it('normalizes dire hero blocks keyed player0..player4 to slots 5-9', () => {
+    const snapshot = parseGsiPayload({
+      player: {
+        team2: { player0: { name: 'R1' } },
+        team3: { player0: { name: 'D1' } },
+      },
+      hero: {
+        team2: { player0: { name: 'npc_dota_hero_luna' } },
+        team3: { player0: { name: 'npc_dota_hero_lich' } },
+      },
+    })
+    const bySlot = new Map(snapshot.players.map((p) => [p.slotIndex, p.heroNpcName]))
+    expect(bySlot.get(0)).toBe('luna')
+    expect(bySlot.get(5)).toBe('lich')
   })
 
   it('extracts the match id for draft-session identity', () => {
@@ -104,6 +145,7 @@ describe('parseGsiPayload', () => {
       matchId: null,
       players: [],
       localPlayer: null,
+      localHeroNpcName: null,
     })
   })
 
@@ -125,7 +167,7 @@ describe('parseGsiPayload', () => {
       },
     })
     expect(snapshot.players).toEqual([
-      { slotIndex: 0, name: 'Valid', accountId: null },
+      { slotIndex: 0, name: 'Valid', accountId: null, heroNpcName: null },
     ])
   })
 


### PR DESCRIPTION
## What

Hero model picks now come **straight from GSI** — no OCR, no ML training. Grounded in the user's real captures: while spectating, \`hero.team2/team3.playerN\` carries each player's picked model (\`npc_dota_hero_slardar\` etc.); while playing, the root \`hero\` block carries your own (\`npc_dota_hero_clinkz\` in the live capture).

- **Parser**: spectator hero blocks map per-player models onto the same normalized 0–9 slots as allplayers (including the dire \`player0–4\` numbering variant); playing mode extracts the local model. Empty hero names = not picked yet. Pure + fixture-tested.
- **Stream board**: \`StreamPlayerRow.model\` (npcName, displayName, portraitPath) — rendered as a portrait beside the player name. Display names resolve via the DB (npc short name minus underscores = Windrun short name, e.g. \`sand_king\` → \`sandking\`) with a title-cased fallback; portraits ride the existing icon cache, since the npc short name IS the Valve CDN key.
- \`StreamGsiInfo.playerModels\` — additive protocol change.

## Relation to the OCR idea

OCR of the on-screen hero-name text stays on the roadmap as the **playing-mode fallback** (GSI only reports your own model when playing). The proposed approach holds up well there: names are always English even on localized clients, and matching against the closed 126-hero vocabulary (with prefix matching for truncations like "KEEPER OF THE LI...") makes recognition nearly foolproof — tesseract.js (WASM, no native modules) when we get to it.

This also effectively supersedes the \`modelSelectionMarker\` disambiguation problem for spectators: models are observed directly rather than inferred from silent turns.

Independent of #106 (no file overlap).

## Tests

506 passing — new parser cases (spectator hero blocks, local hero, dire slot normalization, unpicked-empty-name) and board model attachment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)