### PR TITLE
fix(stream): game-window capture, async PNG encode, guard rejection cap

### DIFF
--- a/src/core/domain/scan-processor.ts
+++ b/src/core/domain/scan-processor.ts
@@ -27,6 +27,7 @@ import {
   filterRelevantHeroTraps,
 } from './op-trap-filter'
 import { determineTopTierEntities } from './top-tier'
+import { RESCAN_GUARD_MAX_CONSECUTIVE_REJECTIONS } from '@shared/constants/thresholds'
 
 // @DEV-GUIDE: Central business logic — transforms raw ML scan results into a fully-enriched
 // OverlayDataPayload for the overlay UI. This is pure TypeScript with ZERO Electron imports.
@@ -73,6 +74,12 @@ export interface ScanProcessorOutput {
    * callers (auto-rescan) must not treat the scan as fresh evidence.
    */
   rescanRejected?: boolean
+  /**
+   * True when the guard hit RESCAN_GUARD_MAX_CONSECUTIVE_REJECTIONS and this
+   * (still-contaminated-looking) rescan was accepted as the new baseline —
+   * escape hatch against a poisoned baseline stalling updates forever.
+   */
+  rescanRebaselined?: boolean
 }
 
 /**
@@ -113,6 +120,7 @@ export function processScanResults(
   let standard: ScanResult[]
   let selectedAbilities: ScanResult[]
   let rescanRejected = false
+  let rescanRebaselined = false
 
   if (isInitialScan) {
     const initial = rawResults as InitialScanResults
@@ -120,6 +128,7 @@ export function processScanResults(
     standard = initial.standard
     selectedAbilities = initial.selectedAbilities
     state.selectedAbilitiesCache = [...selectedAbilities]
+    state.rescanRejectionStreak = 0
 
     // Cache pool for future rescans
     state.initialPoolAbilitiesCache = {
@@ -143,12 +152,23 @@ export function processScanResults(
     // Rescan: rawResults = newly identified selected/picked abilities
     const pickedAbilities = rawResults as ScanResult[]
 
-    if (isRescanContaminated(state.selectedAbilitiesCache, pickedAbilities)) {
+    const contaminated = isRescanContaminated(
+      state.selectedAbilitiesCache,
+      pickedAbilities,
+    )
+    if (
+      contaminated &&
+      state.rescanRejectionStreak < RESCAN_GUARD_MAX_CONSECUTIVE_REJECTIONS
+    ) {
       // Discard this capture: keep state untouched and rebuild the payload from
       // the last accepted picks so consumers still get a consistent refresh.
       rescanRejected = true
+      state.rescanRejectionStreak += 1
       selectedAbilities = state.selectedAbilitiesCache
     } else {
+      // Clean scan, or the rejection cap was hit — accept and re-baseline.
+      rescanRebaselined = contaminated
+      state.rescanRejectionStreak = 0
       const pickedNames = new Set(
         pickedAbilities.map((a) => a.name).filter(Boolean) as string[],
       )
@@ -416,7 +436,7 @@ export function processScanResults(
     modelsCoords: modelCoords,
   }
 
-  return { overlayPayload, updatedState: state, rescanRejected }
+  return { overlayPayload, updatedState: state, rescanRejected, rescanRebaselined }
 }
 
 // ---------------------------------------------------------------------------
@@ -437,6 +457,7 @@ function cloneState(state: DraftSessionState): DraftSessionState {
     mySelectedModelDbHeroId: state.mySelectedModelDbHeroId,
     mySelectedModelHeroOrder: state.mySelectedModelHeroOrder,
     selectedAbilitiesCache: [...state.selectedAbilitiesCache],
+    rescanRejectionStreak: state.rescanRejectionStreak,
   }
 }
 

--- a/src/core/domain/types.ts
+++ b/src/core/domain/types.ts
@@ -73,6 +73,8 @@ export interface DraftSessionState {
   mySelectedModelHeroOrder: number | null
   /** Last ACCEPTED selected-abilities scan — baseline for the rescan contamination guard. */
   selectedAbilitiesCache: ScanResult[]
+  /** Consecutive contamination-guard rejections; capped so rejections can't stall forever. */
+  rescanRejectionStreak: number
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/services/scan-processing-service.ts
+++ b/src/main/services/scan-processing-service.ts
@@ -79,6 +79,7 @@ export function createScanProcessingService(
             mySelectedModelDbHeroId: state.mySelectedModelDbHeroId,
             mySelectedModelHeroOrder: state.mySelectedModelHeroOrder,
             selectedAbilitiesCache: state.selectedAbilitiesCache,
+            rescanRejectionStreak: state.rescanRejectionStreak,
           },
           deps: {
             heroes: dbService.heroes,
@@ -106,12 +107,18 @@ export function createScanProcessingService(
           mySelectedModelHeroOrder:
             output.updatedState.mySelectedModelHeroOrder,
           selectedAbilitiesCache: output.updatedState.selectedAbilitiesCache,
+          rescanRejectionStreak: output.updatedState.rescanRejectionStreak,
           lastRescanRejected: output.rescanRejected === true,
         })
 
         if (output.rescanRejected) {
           logger.warn(
             'Rescan discarded by contamination guard (pick slot obscured); state unchanged',
+          )
+        }
+        if (output.rescanRebaselined) {
+          logger.warn(
+            'Contamination-guard rejection cap reached — accepted scan as new baseline',
           )
         }
 

--- a/src/main/services/scan-trigger-service.ts
+++ b/src/main/services/scan-trigger-service.ts
@@ -1,5 +1,7 @@
+import { screen } from 'electron'
 import sharp from 'sharp'
 import log from 'electron-log/main'
+import { GAME_WINDOW_TITLE } from './window-tracker-service'
 import type { MlService } from './ml-service'
 import type { DatabaseService } from './database-service'
 import type { LayoutService } from './layout-service'
@@ -69,7 +71,30 @@ export function createScanTriggerService(
         }
 
         appStore.setState({ mlStatus: 'scanning' })
-        let screenshotBuffer = await screenshotService.capture()
+
+        // Fullscreen/borderless: capture ONLY the game window — far cheaper than a
+        // full-display capture session and it leaves the cursor/compositor alone.
+        // Windowed mode (game smaller than the display) keeps the screen path,
+        // whose crop logic below aligns coordinates to the game client area.
+        const primary = screen.getPrimaryDisplay()
+        const physicalScreen = {
+          width: Math.round(primary.size.width * primary.scaleFactor),
+          height: Math.round(primary.size.height * primary.scaleFactor),
+        }
+        const gameBounds = windowTracker.getGameWindowPhysicalBounds()
+        const isFullscreen =
+          !gameBounds ||
+          (gameBounds.width >= physicalScreen.width &&
+            gameBounds.height >= physicalScreen.height)
+
+        let screenshotBuffer: Buffer | null = null
+        if (isFullscreen) {
+          screenshotBuffer = await screenshotService.captureWindow(
+            GAME_WINDOW_TITLE,
+            physicalScreen,
+          )
+        }
+        screenshotBuffer ??= await screenshotService.capture()
 
         const layout = layoutService.getLayout(resolution)
         if (!layout) {
@@ -82,7 +107,6 @@ export function createScanTriggerService(
 
         // In windowed mode, crop the full-screen screenshot to the game window
         // so that JSON coordinates (relative to the game window) align correctly
-        const gameBounds = windowTracker.getGameWindowPhysicalBounds()
         if (gameBounds) {
           const meta = await sharp(screenshotBuffer).metadata()
           const screenW = meta.width ?? 0

--- a/src/main/services/screenshot-service.ts
+++ b/src/main/services/screenshot-service.ts
@@ -1,25 +1,66 @@
 import { desktopCapturer, screen } from 'electron'
+import sharp from 'sharp'
 import log from 'electron-log/main'
 
-// @DEV-GUIDE: Captures the primary display via Electron's native desktopCapturer.
-// The previous screenshot-desktop implementation spawned a .bat file through
-// cmd.exe, which required ASAR-unpacking and produced two classes of user-facing
-// scan failures: #74 ("ENOENT: no such file or directory" — unpacked script path)
-// and #76 ("spawn cmd.exe ENOENT" — cmd not resolvable). Native capture has no
-// child processes, no ASAR concerns, and no PATH dependency.
+// @DEV-GUIDE: Captures via Electron's native desktopCapturer. Two paths:
+// - capture(): full primary display at PHYSICAL resolution (mapper/calibration and
+//   the windowed-mode scan fallback — windowed scans crop to game bounds downstream).
+// - captureWindow(title, expectedSize): a single window source by exact title —
+//   the scan path for fullscreen/borderless Dota. Capturing only the game window
+//   avoids the full-display Windows Graphics Capture session that hitches the game
+//   (and briefly the cursor) every auto-rescan tick. Returns null when the source
+//   is missing or the captured size deviates from expectedSize (e.g. windowed mode,
+//   where the window includes its frame) — callers fall back to capture().
 //
-// Returns a PNG buffer of the full primary display at PHYSICAL resolution
-// (thumbnailSize is requested in physical pixels so layout coordinates align).
-// Windowed-mode cropping happens in ml-handlers.ts.
+// PNG encoding is NOT done with NativeImage.toPNG(): that is synchronous on the
+// main process thread (~100ms+ at 1440p) and froze the event loop once auto-rescan
+// started running every 5s. Instead the raw BGRA bitmap is swapped to RGBA (cheap)
+// and encoded by sharp on the libuv threadpool, keeping the main thread responsive.
 //
-// The old TTL-cache/prefetch layer was removed with the rewrite: it was never
-// enabled (startPrefetch had no callers) and both call sites force-bypassed the
-// cache anyway. Native capture is fast enough to run per scan.
+// The previous screenshot-desktop implementation spawned a .bat through cmd.exe
+// (issues #74/#76) — never reintroduce child-process capture.
 
 const logger = log.scope('screenshot')
 
+const WINDOW_SIZE_TOLERANCE_PX = 2
+// Fast compression: scan screenshots are transient (worker decodes them right
+// away); trading size for encode speed keeps the threadpool stall negligible.
+const PNG_COMPRESSION_LEVEL = 1
+
 export interface ScreenshotService {
+  /** Full primary display at physical resolution. */
   capture(): Promise<Buffer>
+  /**
+   * Capture one window by exact title at the expected physical size. Null when
+   * the window source is unavailable or the frame size doesn't match.
+   */
+  captureWindow(
+    title: string,
+    expectedSize: { width: number; height: number },
+  ): Promise<Buffer | null>
+}
+
+/** Electron bitmaps are BGRA; sharp expects RGBA — swap in place (a few ms). */
+function bgraToRgba(buffer: Buffer): Buffer {
+  for (let i = 0; i < buffer.length; i += 4) {
+    const blue = buffer[i]
+    buffer[i] = buffer[i + 2]
+    buffer[i + 2] = blue
+  }
+  return buffer
+}
+
+async function encodePng(thumbnail: Electron.NativeImage): Promise<Buffer> {
+  const size = thumbnail.getSize()
+  const raw = thumbnail.toBitmap()
+  if (raw.length === 0 || size.width === 0 || size.height === 0) {
+    throw new Error('Capture returned an empty image')
+  }
+  return sharp(bgraToRgba(raw), {
+    raw: { width: size.width, height: size.height, channels: 4 },
+  })
+    .png({ compressionLevel: PNG_COMPRESSION_LEVEL })
+    .toBuffer()
 }
 
 export function createScreenshotService(): ScreenshotService {
@@ -42,16 +83,51 @@ export function createScreenshotService(): ScreenshotService {
         throw new Error('No screen sources available for capture')
       }
 
-      const png = source.thumbnail.toPNG()
-      if (png.length === 0) {
-        throw new Error('Screen capture returned an empty image')
-      }
-
+      const png = await encodePng(source.thumbnail)
       logger.debug('Captured primary display', {
         sourceId: source.id,
         ...thumbnailSize,
       })
       return png
+    },
+
+    async captureWindow(title, expectedSize): Promise<Buffer | null> {
+      try {
+        const sources = await desktopCapturer.getSources({
+          types: ['window'],
+          thumbnailSize: expectedSize,
+        })
+        const source = sources.find((s) => s.name === title)
+        if (!source) {
+          logger.debug('Window source not found, falling back', { title })
+          return null
+        }
+
+        const size = source.thumbnail.getSize()
+        if (
+          Math.abs(size.width - expectedSize.width) > WINDOW_SIZE_TOLERANCE_PX ||
+          Math.abs(size.height - expectedSize.height) > WINDOW_SIZE_TOLERANCE_PX
+        ) {
+          // Windowed mode (frame included) or unexpected scaling — coordinates
+          // would misalign; let the caller use the screen path instead.
+          logger.debug('Window capture size mismatch, falling back', {
+            title,
+            captured: size,
+            expected: expectedSize,
+          })
+          return null
+        }
+
+        const png = await encodePng(source.thumbnail)
+        logger.debug('Captured game window', { title, ...size })
+        return png
+      } catch (error) {
+        logger.warn('Window capture failed, falling back to screen', {
+          title,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return null
+      }
     },
   }
 }

--- a/src/main/services/window-tracker-service.ts
+++ b/src/main/services/window-tracker-service.ts
@@ -102,7 +102,7 @@ function loadBindings(): typeof bindings {
   }
 }
 
-const GAME_WINDOW_TITLE = 'Dota 2'
+export const GAME_WINDOW_TITLE = 'Dota 2'
 
 interface RawGameWindowBounds {
   physical: GameWindowBounds

--- a/src/main/store/draft-store.ts
+++ b/src/main/store/draft-store.ts
@@ -26,6 +26,8 @@ export interface DraftSessionSlice {
   mySelectedModelHeroOrder: number | null
   /** Last ACCEPTED selected-abilities scan (rescan contamination guard baseline). */
   selectedAbilitiesCache: ScanResult[]
+  /** Consecutive contamination-guard rejections (capped; see scan-processor). */
+  rescanRejectionStreak: number
   /** True when the most recent rescan was discarded by the contamination guard. */
   lastRescanRejected: boolean
   /** Attributed pick events (experimental auto-rescan); empty otherwise. */
@@ -52,6 +54,7 @@ export function createDraftStore() {
     mySelectedModelDbHeroId: null,
     mySelectedModelHeroOrder: null,
     selectedAbilitiesCache: [],
+    rescanRejectionStreak: 0,
     lastRescanRejected: false,
     draftTimeline: [],
 
@@ -65,6 +68,7 @@ export function createDraftStore() {
         mySelectedModelDbHeroId: null,
         mySelectedModelHeroOrder: null,
         selectedAbilitiesCache: [],
+        rescanRejectionStreak: 0,
         lastRescanRejected: false,
         draftTimeline: [],
       }),

--- a/src/shared/constants/thresholds.ts
+++ b/src/shared/constants/thresholds.ts
@@ -39,6 +39,10 @@ export const STREAM_PICK_FEED_LENGTH = 20
 
 // Experimental auto-rescan (GSI-driven draft tracking)
 export const AUTO_RESCAN_INTERVAL_MS = 5_000
+// Contamination guard: after this many CONSECUTIVE rejected rescans, accept the
+// next one and re-baseline — a poisoned baseline (confident misread of an empty
+// slot) or a long-lived in-game overlay must not stall updates indefinitely.
+export const RESCAN_GUARD_MAX_CONSECUTIVE_REJECTIONS = 3
 
 // Per-player draft score: score = clamp01(meanWinrate + weight * Σ clamped pair lifts).
 // MAX_PAIR_DELTA caps a single pair's contribution so one outlier synergy row

--- a/tests/unit/core/domain/scan-processor.test.ts
+++ b/tests/unit/core/domain/scan-processor.test.ts
@@ -137,6 +137,7 @@ function makeInitialState(): DraftSessionState {
     mySelectedModelDbHeroId: null,
     mySelectedModelHeroOrder: null,
     selectedAbilitiesCache: [],
+    rescanRejectionStreak: 0,
   }
 }
 
@@ -398,6 +399,44 @@ describe('processScanResults', () => {
         expect(
           corrected.updatedState.selectedAbilitiesCache.map((s) => s.name),
         ).toEqual(['firestorm'])
+      })
+
+      it('accepts and re-baselines after the consecutive-rejection cap', () => {
+        const first = acceptedFirstRescan()
+        const contaminatedResults = [makeScanResult(null, 0, 1, false, 0.4)]
+
+        // Rejections up to the cap
+        let state = first.updatedState
+        for (let i = 1; i <= 3; i++) {
+          const rejected = rescanWith(state, contaminatedResults)
+          expect(rejected.rescanRejected).toBe(true)
+          expect(rejected.updatedState.rescanRejectionStreak).toBe(i)
+          state = rejected.updatedState
+        }
+
+        // Cap reached: the 4th contaminated scan is accepted as the new baseline
+        const rebaselined = rescanWith(state, contaminatedResults)
+        expect(rebaselined.rescanRejected).toBe(false)
+        expect(rebaselined.rescanRebaselined).toBe(true)
+        expect(rebaselined.updatedState.rescanRejectionStreak).toBe(0)
+        expect(
+          rebaselined.updatedState.selectedAbilitiesCache.map((s) => s.name),
+        ).toEqual([null])
+      })
+
+      it('a clean scan resets the rejection streak', () => {
+        const first = acceptedFirstRescan()
+        const rejected = rescanWith(first.updatedState, [
+          makeScanResult(null, 0, 1, false, 0.4),
+        ])
+        expect(rejected.updatedState.rescanRejectionStreak).toBe(1)
+
+        const clean = rescanWith(rejected.updatedState, [
+          makeScanResult('fireball', 0, 1, false),
+        ])
+        expect(clean.rescanRejected).toBe(false)
+        expect(clean.rescanRebaselined).toBe(false)
+        expect(clean.updatedState.rescanRejectionStreak).toBe(0)
       })
 
       it('never rejects when there are no prior confident picks', () => {

--- a/tests/unit/core/ml/screenshot-service.test.ts
+++ b/tests/unit/core/ml/screenshot-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import sharp from 'sharp'
 
 // Mock electron's desktopCapturer + screen
 const mockGetSources = vi.fn()
@@ -23,11 +24,33 @@ vi.mock('electron-log/main', () => ({
 
 import { createScreenshotService } from '../../../../src/main/services/screenshot-service'
 
-function makeSource(id: string, displayId: string, png: Buffer) {
+/** 2x2 BGRA bitmap: every pixel B=10, G=20, R=30, A=255. */
+function makeBgraBitmap(width = 2, height = 2): Buffer {
+  const buffer = Buffer.alloc(width * height * 4)
+  for (let i = 0; i < buffer.length; i += 4) {
+    buffer[i] = 10
+    buffer[i + 1] = 20
+    buffer[i + 2] = 30
+    buffer[i + 3] = 255
+  }
+  return buffer
+}
+
+function makeSource(
+  id: string,
+  displayId: string,
+  options: { name?: string; width?: number; height?: number; empty?: boolean } = {},
+) {
+  const width = options.width ?? 2
+  const height = options.height ?? 2
   return {
     id,
     display_id: displayId,
-    thumbnail: { toPNG: () => png },
+    name: options.name ?? '',
+    thumbnail: {
+      toBitmap: () => (options.empty ? Buffer.alloc(0) : makeBgraBitmap(width, height)),
+      getSize: () => ({ width, height }),
+    },
   }
 }
 
@@ -39,67 +62,109 @@ describe('ScreenshotService (desktopCapturer)', () => {
       size: { width: 2560, height: 1440 },
       scaleFactor: 1,
     })
-    mockGetSources.mockResolvedValue([
-      makeSource('screen:42', '42', Buffer.from('primary-png')),
-    ])
+    mockGetSources.mockResolvedValue([makeSource('screen:42', '42')])
   })
 
-  it('requests screen sources at the primary display physical resolution', async () => {
-    mockGetPrimaryDisplay.mockReturnValue({
-      id: 42,
-      size: { width: 1707, height: 1067 }, // logical points at 150% scaling
-      scaleFactor: 1.5,
+  describe('capture (full screen)', () => {
+    it('requests screen sources at the primary display physical resolution', async () => {
+      mockGetPrimaryDisplay.mockReturnValue({
+        id: 42,
+        size: { width: 1707, height: 1067 }, // logical points at 150% scaling
+        scaleFactor: 1.5,
+      })
+
+      const service = createScreenshotService()
+      await service.capture()
+
+      expect(mockGetSources).toHaveBeenCalledWith({
+        types: ['screen'],
+        thumbnailSize: { width: 2561, height: 1601 }, // rounded physical pixels
+      })
     })
 
-    const service = createScreenshotService()
-    await service.capture()
+    it('encodes the BGRA bitmap into a PNG with swapped channels', async () => {
+      const service = createScreenshotService()
+      const png = await service.capture()
 
-    expect(mockGetSources).toHaveBeenCalledWith({
-      types: ['screen'],
-      thumbnailSize: { width: 2561, height: 1601 }, // rounded physical pixels
+      const { data, info } = await sharp(png)
+        .raw()
+        .toBuffer({ resolveWithObject: true })
+      expect(info.width).toBe(2)
+      expect(info.height).toBe(2)
+      // BGRA (10,20,30) must come out as RGB (30,20,10)
+      expect(data[0]).toBe(30)
+      expect(data[1]).toBe(20)
+      expect(data[2]).toBe(10)
+    })
+
+    it('selects the source matching the primary display id among several', async () => {
+      mockGetSources.mockResolvedValue([
+        makeSource('screen:7', '7', { width: 4, height: 4 }),
+        makeSource('screen:42', '42', { width: 2, height: 2 }),
+      ])
+
+      const service = createScreenshotService()
+      const png = await service.capture()
+      const meta = await sharp(png).metadata()
+      expect(meta.width).toBe(2)
+    })
+
+    it('throws when no screen sources are available', async () => {
+      mockGetSources.mockResolvedValue([])
+      const service = createScreenshotService()
+      await expect(service.capture()).rejects.toThrow('No screen sources')
+    })
+
+    it('throws when the capture produces an empty image', async () => {
+      mockGetSources.mockResolvedValue([
+        makeSource('screen:42', '42', { empty: true }),
+      ])
+      const service = createScreenshotService()
+      await expect(service.capture()).rejects.toThrow('empty image')
     })
   })
 
-  it('returns the PNG buffer of the primary display source', async () => {
-    const service = createScreenshotService()
-    const result = await service.capture()
-    expect(result).toEqual(Buffer.from('primary-png'))
-  })
+  describe('captureWindow', () => {
+    it('captures a window source matched by exact title', async () => {
+      mockGetSources.mockResolvedValue([
+        makeSource('window:1', '', { name: 'Discord', width: 2, height: 2 }),
+        makeSource('window:2', '', { name: 'Dota 2', width: 2, height: 2 }),
+      ])
 
-  it('selects the source matching the primary display id among several', async () => {
-    mockGetSources.mockResolvedValue([
-      makeSource('screen:7', '7', Buffer.from('secondary-png')),
-      makeSource('screen:42', '42', Buffer.from('primary-png')),
-    ])
+      const service = createScreenshotService()
+      const png = await service.captureWindow('Dota 2', { width: 2, height: 2 })
 
-    const service = createScreenshotService()
-    const result = await service.capture()
-    expect(result).toEqual(Buffer.from('primary-png'))
-  })
+      expect(mockGetSources).toHaveBeenCalledWith({
+        types: ['window'],
+        thumbnailSize: { width: 2, height: 2 },
+      })
+      expect(png).not.toBeNull()
+      const meta = await sharp(png as Buffer).metadata()
+      expect(meta.width).toBe(2)
+    })
 
-  it('falls back to the first source when no display id matches', async () => {
-    mockGetSources.mockResolvedValue([
-      makeSource('screen:7', '', Buffer.from('only-png')),
-    ])
+    it('returns null when the window is not among the sources', async () => {
+      mockGetSources.mockResolvedValue([
+        makeSource('window:1', '', { name: 'Discord' }),
+      ])
+      const service = createScreenshotService()
+      expect(await service.captureWindow('Dota 2', { width: 2, height: 2 })).toBeNull()
+    })
 
-    const service = createScreenshotService()
-    const result = await service.capture()
-    expect(result).toEqual(Buffer.from('only-png'))
-  })
+    it('returns null when the captured size deviates from the expected size', async () => {
+      // Windowed mode: the window includes its frame, so it is larger than the
+      // client area the caller expects
+      mockGetSources.mockResolvedValue([
+        makeSource('window:2', '', { name: 'Dota 2', width: 8, height: 8 }),
+      ])
+      const service = createScreenshotService()
+      expect(await service.captureWindow('Dota 2', { width: 2, height: 2 })).toBeNull()
+    })
 
-  it('throws when no screen sources are available', async () => {
-    mockGetSources.mockResolvedValue([])
-
-    const service = createScreenshotService()
-    await expect(service.capture()).rejects.toThrow('No screen sources')
-  })
-
-  it('throws when the capture produces an empty image', async () => {
-    mockGetSources.mockResolvedValue([
-      makeSource('screen:42', '42', Buffer.alloc(0)),
-    ])
-
-    const service = createScreenshotService()
-    await expect(service.capture()).rejects.toThrow('empty image')
+    it('returns null instead of throwing when capture fails', async () => {
+      mockGetSources.mockRejectedValue(new Error('capture backend gone'))
+      const service = createScreenshotService()
+      expect(await service.captureWindow('Dota 2', { width: 2, height: 2 })).toBeNull()
+    })
   })
 })


### PR DESCRIPTION
## What

Fixes all three live-play reports (lag, cursor flicker, auto-updates stopping), each diagnosed from the log:

1. **Lag** — \`NativeImage.toPNG()\` encoded the full 1440p display **synchronously on the main process thread** every auto-rescan tick: ~100ms+ event-loop freezes every 5 s (UI, SSE pushes, everything). Capture now takes the raw BGRA bitmap, swaps channels (a few ms), and PNG-encodes via sharp on the libuv threadpool — the main thread stays responsive.
2. **Cursor flicker** — nothing moves the mouse (cursor parking was deleted in #106); the flicker was the **full-display Windows Graphics Capture session** starting/stopping each tick. Scans now capture **only the "Dota 2" window** by exact title when the game is fullscreen/borderless — the compositor and cursor are left alone. Windowed mode keeps the screen+crop path (window capture would include the frame); the captured size is validated against the expected physical size with automatic fallback to the screen path, so geometry can never silently misalign.
3. **Auto-updates stopping** — the log shows an 8-consecutive contamination-guard rejection streak (~40 s of frozen state). Rejections are now capped at **3 consecutive** (\`RESCAN_GUARD_MAX_CONSECUTIVE_REJECTIONS\`); the next scan is accepted as a new baseline (\`rescanRebaselined\`, logged) — so a poisoned baseline (confident misread of an empty slot) or a long-lived in-game overlay stalls the board for at most ~20 s instead of forever.

The mapper/calibration \`capture()\` keeps full-screen semantics (also async-encoded now).

## Tests

517 passing — rewritten screenshot-service suite (real sharp round-trip verifying the BGRA→RGBA swap, window-source match, size-mismatch fallback, failure fallback) + guard streak tests (reject/reject/reject → rebaseline, clean-scan streak reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)