### PR TITLE
feat(stream): GSI mode observability for playing-vs-spectating validation

### DIFF
--- a/src/core/gsi/parser.ts
+++ b/src/core/gsi/parser.ts
@@ -1,4 +1,4 @@
-import type { GsiPlayer, GsiSnapshot } from './types'
+import type { GsiMode, GsiPlayer, GsiSnapshot } from './types'
 
 // @DEV-GUIDE: Pure GSI payload parser — zero Electron/node imports, fixture-tested.
 // Tolerant by design: Valve's GSI payloads vary by game phase and data sections
@@ -138,4 +138,15 @@ export function parseGsiPayload(json: unknown): GsiSnapshot {
     localPlayer,
     localHeroNpcName,
   }
+}
+
+/**
+ * Classify how a snapshot was produced. Spectating payloads carry allplayers
+ * slots; playing payloads carry only the local player block; menu/loading
+ * payloads carry neither.
+ */
+export function gsiSnapshotMode(snapshot: GsiSnapshot): GsiMode {
+  if (snapshot.players.length > 0) return 'spectating'
+  if (snapshot.localPlayer !== null) return 'playing'
+  return 'unknown'
 }

--- a/src/core/gsi/types.ts
+++ b/src/core/gsi/types.ts
@@ -34,3 +34,7 @@ export interface GsiSnapshot {
 }
 
 export const GSI_HERO_SELECTION_PHASE = 'DOTA_GAMERULES_STATE_HERO_SELECTION'
+
+/** How the snapshot's payload was produced: spectating carries allplayers slots,
+ * playing carries only the local player block. */
+export type GsiMode = 'spectating' | 'playing' | 'unknown'

--- a/src/main/services/auto-rescan-service.ts
+++ b/src/main/services/auto-rescan-service.ts
@@ -6,6 +6,7 @@ import type { StreamServerService } from './stream-server-service'
 import type { ScanTriggerService } from './scan-trigger-service'
 import type { AppStore } from '../store/app-store'
 import { GSI_HERO_SELECTION_PHASE } from '@core/gsi/types'
+import { gsiSnapshotMode } from '@core/gsi/parser'
 import {
   buildTurnSchedule,
   elapsedTurnsBetween,
@@ -86,6 +87,7 @@ export function createAutoRescanService(
       logger.info('Draft started (GSI hero selection)', {
         prevPhase,
         matchId: snapshot.matchId,
+        mode: gsiSnapshotMode(snapshot),
       })
     } else if (prevPhase === GSI_HERO_SELECTION_PHASE) {
       logger.info('Left hero selection (session retained for possible re-entry)', {

--- a/src/main/services/stream-server-service.ts
+++ b/src/main/services/stream-server-service.ts
@@ -7,7 +7,7 @@ import type { OverlayDataPayload } from '@shared/types'
 import type { StreamServerStatusInfo, StreamStateMessage } from '@shared/types/stream'
 import { STREAM_PROTOCOL_VERSION } from '@shared/constants/thresholds'
 import { buildStreamBoardState } from '@core/domain/stream-board'
-import { parseGsiPayload } from '@core/gsi/parser'
+import { parseGsiPayload, gsiSnapshotMode } from '@core/gsi/parser'
 import type { GsiSnapshot } from '@core/gsi/types'
 import type { PickEvent, StreamGsiInfo } from '@shared/types/stream'
 import type { DatabaseService } from './database-service'
@@ -98,10 +98,13 @@ export function createStreamServerService(
   let gsiBroadcastTimer: NodeJS.Timeout | null = null
   const gsiListeners: Array<(snapshot: GsiSnapshot) => void> = []
   // Raw-payload capture for empirical validation (slot ordering, phase names,
-  // AD turn timings): latest payload per game_state, overwritten, throttled.
+  // AD turn timings): latest payload per mode+game_state, overwritten, throttled.
+  // Mode prefix keeps playing captures from overwriting spectating ones.
   const gsiCaptureDir = join(app.getPath('userData'), 'gsi-captures')
   const gsiCaptureLastWrite = new Map<string, number>()
   let gsiLastPlayersLog = ''
+  let gsiLastLocalLog = ''
+  let gsiLastLoggedPhase: string | null = null
 
   // Same path convention as window-manager's loadWindowContent: resolve renderer
   // output relative to the compiled main bundle (out/main -> out/renderer). Works in
@@ -268,15 +271,20 @@ export function createStreamServerService(
     res.end(data)
   }
 
-  function captureGsiPayload(rawBody: string, phase: string | null): void {
+  function captureGsiPayload(
+    rawBody: string,
+    phase: string | null,
+    mode: string,
+  ): void {
     const safePhase = (phase ?? 'unknown').replace(/[^A-Za-z0-9_]/g, '_')
+    const captureKey = `${mode}_${safePhase}`
     const now = Date.now()
-    const lastWrite = gsiCaptureLastWrite.get(safePhase) ?? 0
+    const lastWrite = gsiCaptureLastWrite.get(captureKey) ?? 0
     if (now - lastWrite < 5_000) return
-    gsiCaptureLastWrite.set(safePhase, now)
+    gsiCaptureLastWrite.set(captureKey, now)
     void fs
       .mkdir(gsiCaptureDir, { recursive: true })
-      .then(() => fs.writeFile(join(gsiCaptureDir, `${safePhase}.json`), rawBody))
+      .then(() => fs.writeFile(join(gsiCaptureDir, `${captureKey}.json`), rawBody))
       .catch((error: unknown) => {
         logger.warn('GSI capture write failed', {
           error: error instanceof Error ? error.message : String(error),
@@ -292,6 +300,40 @@ export function createStreamServerService(
     if (mapping !== gsiLastPlayersLog) {
       gsiLastPlayersLog = mapping
       logger.info('GSI player slots', { mapping })
+    }
+  }
+
+  // DEBUG (playing-mode validation): the two logs below make the main log answer
+  // "did GSI see the draft while PLAYING (not spectating)?" — logParsedPlayers is
+  // silent in playing mode (no allplayers block), so without these the log can't
+  // distinguish a working playing-mode feed from a dead one.
+  function logPhaseTransition(snapshot: GsiSnapshot): void {
+    if (snapshot.gamePhase === gsiLastLoggedPhase) return
+    const from = gsiLastLoggedPhase
+    gsiLastLoggedPhase = snapshot.gamePhase
+    logger.info('GSI phase transition', {
+      from,
+      to: snapshot.gamePhase,
+      mode: gsiSnapshotMode(snapshot),
+      matchId: snapshot.matchId,
+      clockTime: snapshot.clockTime,
+      playerCount: snapshot.players.length,
+      localPlayer: snapshot.localPlayer?.name ?? null,
+    })
+  }
+
+  function logLocalPlayer(snapshot: GsiSnapshot): void {
+    if (!snapshot.localPlayer) return
+    const line = `${snapshot.localPlayer.name}${
+      snapshot.localHeroNpcName ? `=${snapshot.localHeroNpcName}` : ''
+    }`
+    if (line !== gsiLastLocalLog) {
+      gsiLastLocalLog = line
+      logger.info('GSI local player (playing mode)', {
+        name: snapshot.localPlayer.name,
+        accountId: snapshot.localPlayer.accountId,
+        heroModel: snapshot.localHeroNpcName,
+      })
     }
   }
 
@@ -333,8 +375,10 @@ export function createStreamServerService(
         const wasConnected = gsiConnected()
         gsiSnapshot = parseGsiPayload(json)
         gsiLastAt = Date.now()
-        captureGsiPayload(rawBody, gsiSnapshot.gamePhase)
+        captureGsiPayload(rawBody, gsiSnapshot.gamePhase, gsiSnapshotMode(gsiSnapshot))
         logParsedPlayers(gsiSnapshot)
+        logPhaseTransition(gsiSnapshot)
+        logLocalPlayer(gsiSnapshot)
         if (!wasConnected) {
           appStore.setState({ gsiConnected: true })
           logger.info('GSI connected')

--- a/tests/unit/core/gsi/parser.test.ts
+++ b/tests/unit/core/gsi/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseGsiPayload } from '@core/gsi/parser'
+import { parseGsiPayload, gsiSnapshotMode } from '@core/gsi/parser'
 
 // Fixtures are synthetic but shape-accurate for Dota GSI (provider/map/player sections).
 // The real-lobby capture spike (plan phase 4) replaces/extends these with recorded
@@ -226,5 +226,21 @@ describe('parseGsiPayload', () => {
   it('accepts clock_time of zero', () => {
     const snapshot = parseGsiPayload({ map: { clock_time: 0, game_state: 'X' } })
     expect(snapshot.clockTime).toBe(0)
+  })
+})
+
+describe('gsiSnapshotMode', () => {
+  it('classifies spectator payloads as spectating', () => {
+    expect(gsiSnapshotMode(parseGsiPayload(SPECTATOR_PAYLOAD))).toBe('spectating')
+  })
+
+  it('classifies local-player payloads as playing', () => {
+    expect(gsiSnapshotMode(parseGsiPayload(PLAYING_PAYLOAD))).toBe('playing')
+  })
+
+  it('classifies heartbeat payloads without player data as unknown', () => {
+    expect(
+      gsiSnapshotMode(parseGsiPayload({ provider: { name: 'Dota 2' } })),
+    ).toBe('unknown')
   })
 })


### PR DESCRIPTION
## What

- `gsiSnapshotMode()`: classifies GSI snapshots as spectating (allplayers present) / playing (local player block only) / unknown (heartbeats)
- `GSI phase transition` log on every game_state change with mode, matchId, clockTime, player count, local player name
- `GSI local player (playing mode)` log (change-deduped) with name, account id, and picked hero model
- Raw `gsi-captures/` files are mode-prefixed so playing captures no longer overwrite spectating ones

## Why

The draft-start anchor is phase-based and mode-agnostic, but the logs could not prove playing-mode GSI worked: the player-slots log is silent while playing (no allplayers block), so a working feed and a dead one looked identical. These logs validated playing mode live (own slot via team_slot, own model via the hero block) and every later feature was diagnosed through them.

## Reviewer notes

Stacked on #113; merge second, then rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)