### PR TITLE
perf(scan): cached-source game window capture — skip per-scan getSources

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import { createBackupService } from './services/backup-service'
 import { createMlService } from './services/ml-service'
 import { createLayoutService } from './services/layout-service'
 import { createScreenshotService } from './services/screenshot-service'
+import { createCachedWindowCaptureService } from './services/cached-window-capture-service'
 import { createScanProcessingService } from './services/scan-processing-service'
 import { createStreamServerService } from './services/stream-server-service'
 import { createIconCacheService } from './services/icon-cache-service'
@@ -123,6 +124,9 @@ app.whenReady().then(async () => {
   const mlService = createMlService()
   const layoutService = createLayoutService()
   const screenshotService = createScreenshotService()
+  // Fast scan capture: cached game-window source + overlay-renderer frame
+  // grabs; screenshotService stays the fallback (see the service dev-guide)
+  const cachedWindowCapture = createCachedWindowCaptureService(windowManager)
   const draftStore = createDraftStore()
 
   // @DEV-GUIDE: @zubridge bridge wires the Zustand AppStore in main to all subscribed
@@ -233,6 +237,7 @@ app.whenReady().then(async () => {
     mlService,
     layoutService,
     screenshotService,
+    cachedWindowCapture,
     windowManager,
     scanProcessingService,
     appStore,
@@ -283,6 +288,7 @@ app.whenReady().then(async () => {
     updateService.stopPeriodicChecks()
     windowTracker.stopTracking()
     autoRescanService.stop()
+    cachedWindowCapture.dispose()
     bridge.destroy()
     await streamService.stop()
     await mlService.terminate()

--- a/src/main/services/cached-window-capture-service.ts
+++ b/src/main/services/cached-window-capture-service.ts
@@ -1,0 +1,235 @@
+import { desktopCapturer, ipcMain } from 'electron'
+import log from 'electron-log/main'
+import type { IpcSendMap } from '@shared/ipc/api'
+import type { DecodedScreenshot } from '@core/ml/preprocessing'
+import type { WindowManager } from './window-manager'
+import {
+  CAPTURE_FRAME_TIMEOUT_MS,
+  CAPTURE_IDLE_STOP_MS,
+} from '@shared/constants/thresholds'
+
+// @DEV-GUIDE: The PRIMARY scan capture path for fullscreen/borderless Dota.
+// desktopCapturer.getSources() thumbnails every open window to deliver the one
+// game frame — measured 730-1075ms per scan (1775ms cold, 16 windows), ~85% of
+// total scan latency in the turn-driven auto-rescan flow. This service instead:
+// 1. Resolves the game window's source id ONCE via a thumbnail-free getSources
+//    call ({width:0,height:0} skips the per-window captures entirely).
+// 2. Grabs frames from a persistent getUserMedia(chromeMediaSourceId) stream
+//    living in the OVERLAY RENDERER (capture-agent.ts) — scans exist only while
+//    the overlay is up, so the stream's lifetime matches naturally. Frames come
+//    back as tightly-packed RGBA (the renderer's canvas normalizes whatever
+//    pixel format WGC delivers); main only drops alpha.
+// The renderer request/response correlation (requestId) lives here, which is
+// why the capture:frameResult/sessionEnded send channels are handled in this
+// service rather than in src/main/ipc/.
+//
+// EVERY failure returns null so scan-trigger falls back to the proven
+// getSources path (screenshot-service): source not found, renderer timeout or
+// error, captured size drifting from the expected physical size, or the track
+// dying (game window recreated on resolution change -> renderer reports
+// capture:sessionEnded and the cached id is dropped for re-resolution).
+// After CAPTURE_IDLE_STOP_MS without a request the renderer stream is stopped
+// so the WGC session doesn't outlive the draft; the source id stays cached.
+
+const logger = log.scope('cached-capture')
+
+const WINDOW_SIZE_TOLERANCE_PX = 2
+
+type FrameResult = IpcSendMap['capture:frameResult']
+
+export interface CachedWindowCaptureService {
+  /**
+   * Capture one frame of the window with this exact title at the expected
+   * physical size. Null on any failure — callers fall back to the
+   * screenshot-service getSources path.
+   */
+  captureFrame(
+    title: string,
+    expectedSize: { width: number; height: number },
+  ): Promise<DecodedScreenshot | null>
+  dispose(): void
+}
+
+/** getImageData output is tightly-packed RGBA; drop alpha in one pass. */
+function rgbaToRgb(rgba: Uint8Array, width: number, height: number): Buffer {
+  const rgb = Buffer.allocUnsafe(width * height * 3)
+  for (let src = 0, dst = 0; dst < rgb.length; src += 4, dst += 3) {
+    rgb[dst] = rgba[src]
+    rgb[dst + 1] = rgba[src + 1]
+    rgb[dst + 2] = rgba[src + 2]
+  }
+  return rgb
+}
+
+export function createCachedWindowCaptureService(
+  windowManager: WindowManager,
+): CachedWindowCaptureService {
+  let sourceId: string | null = null
+  let nextRequestId = 1
+  const pending = new Map<number, (result: FrameResult) => void>()
+  let idleTimer: NodeJS.Timeout | null = null
+
+  function onFrameResult(_event: Electron.IpcMainEvent, result: FrameResult): void {
+    pending.get(result.requestId)?.(result)
+  }
+
+  function onSessionEnded(): void {
+    logger.debug('Renderer capture session ended — dropping cached source id')
+    sourceId = null
+  }
+
+  ipcMain.on('capture:frameResult', onFrameResult)
+  ipcMain.on('capture:sessionEnded', onSessionEnded)
+
+  function sendStopToRenderer(): void {
+    const overlay = windowManager.getOverlayWindow()
+    if (overlay && !overlay.isDestroyed()) {
+      overlay.webContents.send('capture:stop')
+    }
+  }
+
+  /** Forget the source and stop the renderer stream — next scan re-resolves. */
+  function invalidate(): void {
+    sourceId = null
+    sendStopToRenderer()
+  }
+
+  function armIdleStop(): void {
+    if (idleTimer) clearTimeout(idleTimer)
+    idleTimer = setTimeout(() => {
+      idleTimer = null
+      logger.debug('Capture idle — stopping renderer stream')
+      sendStopToRenderer()
+    }, CAPTURE_IDLE_STOP_MS)
+  }
+
+  function requestFrame(
+    overlay: Electron.BrowserWindow,
+    id: string,
+    expectedSize: { width: number; height: number },
+  ): Promise<FrameResult | null> {
+    return new Promise((resolve) => {
+      const requestId = nextRequestId++
+      const timer = setTimeout(() => {
+        pending.delete(requestId)
+        resolve(null)
+      }, CAPTURE_FRAME_TIMEOUT_MS)
+      pending.set(requestId, (result) => {
+        clearTimeout(timer)
+        pending.delete(requestId)
+        resolve(result)
+      })
+      overlay.webContents.send('capture:frame', {
+        requestId,
+        sourceId: id,
+        maxWidth: expectedSize.width,
+        maxHeight: expectedSize.height,
+      })
+    })
+  }
+
+  return {
+    async captureFrame(title, expectedSize): Promise<DecodedScreenshot | null> {
+      const overlay = windowManager.getOverlayWindow()
+      if (!overlay || overlay.isDestroyed()) return null
+
+      try {
+        let resolveMs: number | null = null
+        if (sourceId === null) {
+          const start = performance.now()
+          // Zero thumbnailSize skips the expensive per-window thumbnail
+          // captures — this enumerates ids/titles only.
+          const sources = await desktopCapturer.getSources({
+            types: ['window'],
+            thumbnailSize: { width: 0, height: 0 },
+            fetchWindowIcons: false,
+          })
+          resolveMs = Math.round(performance.now() - start)
+          const source = sources.find((s) => s.name === title)
+          if (!source) {
+            logger.debug('Window source not found, falling back', {
+              title,
+              resolveMs,
+              windowCount: sources.length,
+            })
+            return null
+          }
+          sourceId = source.id
+          logger.debug('Resolved game window capture source', {
+            title,
+            sourceId,
+            resolveMs,
+            windowCount: sources.length,
+          })
+        }
+
+        const grabStart = performance.now()
+        const result = await requestFrame(overlay, sourceId, expectedSize)
+        const grabMs = Math.round(performance.now() - grabStart)
+
+        if (
+          !result ||
+          !result.ok ||
+          result.data === undefined ||
+          result.width === undefined ||
+          result.height === undefined
+        ) {
+          logger.debug('Cached-source frame grab failed, falling back', {
+            title,
+            grabMs,
+            error: result ? (result.error ?? 'malformed response') : 'timeout',
+          })
+          invalidate()
+          return null
+        }
+
+        if (
+          Math.abs(result.width - expectedSize.width) > WINDOW_SIZE_TOLERANCE_PX ||
+          Math.abs(result.height - expectedSize.height) > WINDOW_SIZE_TOLERANCE_PX ||
+          result.data.length < result.width * result.height * 4
+        ) {
+          // Windowed mode / resolution change — coordinates would misalign
+          logger.debug('Cached-source capture size mismatch, falling back', {
+            title,
+            captured: { width: result.width, height: result.height },
+            expected: expectedSize,
+          })
+          invalidate()
+          return null
+        }
+
+        const convertStart = performance.now()
+        const rgb = rgbaToRgb(result.data, result.width, result.height)
+        logger.debug('Captured game window (cached source)', {
+          title,
+          grabMs,
+          convertMs: Math.round(performance.now() - convertStart),
+          ...(resolveMs !== null ? { resolveMs } : {}),
+          width: result.width,
+          height: result.height,
+        })
+
+        armIdleStop()
+        return { data: rgb, width: result.width, height: result.height }
+      } catch (error) {
+        logger.warn('Cached window capture failed, falling back', {
+          title,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        invalidate()
+        return null
+      }
+    },
+
+    dispose(): void {
+      if (idleTimer) {
+        clearTimeout(idleTimer)
+        idleTimer = null
+      }
+      ipcMain.removeListener('capture:frameResult', onFrameResult)
+      ipcMain.removeListener('capture:sessionEnded', onSessionEnded)
+      pending.clear()
+      sendStopToRenderer()
+    },
+  }
+}

--- a/src/main/services/scan-trigger-service.ts
+++ b/src/main/services/scan-trigger-service.ts
@@ -6,6 +6,7 @@ import type { MlService } from './ml-service'
 import type { DatabaseService } from './database-service'
 import type { LayoutService } from './layout-service'
 import type { ScreenshotService } from './screenshot-service'
+import type { CachedWindowCaptureService } from './cached-window-capture-service'
 import type { DecodedScreenshot } from '@core/ml/preprocessing'
 import type { WindowManager } from './window-manager'
 import type { ScanProcessingService } from './scan-processing-service'
@@ -43,6 +44,7 @@ export function createScanTriggerService(
   mlService: MlService,
   layoutService: LayoutService,
   screenshotService: ScreenshotService,
+  cachedWindowCapture: CachedWindowCaptureService,
   windowManager: WindowManager,
   scanProcessingService: ScanProcessingService,
   appStore: AppStore,
@@ -96,9 +98,16 @@ export function createScanTriggerService(
           (gameBounds.width >= physicalScreen.width &&
             gameBounds.height >= physicalScreen.height)
 
+        // Capture cascade: cached-source frame grab (persistent renderer
+        // stream, ~10-50ms) -> per-scan getSources window capture (~1s) ->
+        // full-display capture. Each step returns null to hand off downward.
         let screenshot: DecodedScreenshot | null = null
         if (isFullscreen) {
-          screenshot = await screenshotService.captureWindow(
+          screenshot = await cachedWindowCapture.captureFrame(
+            GAME_WINDOW_TITLE,
+            physicalScreen,
+          )
+          screenshot ??= await screenshotService.captureWindow(
             GAME_WINDOW_TITLE,
             physicalScreen,
           )

--- a/src/main/services/screenshot-service.ts
+++ b/src/main/services/screenshot-service.ts
@@ -6,7 +6,9 @@ import type { DecodedScreenshot } from '@core/ml/preprocessing'
 // - capture(): full primary display at PHYSICAL resolution (mapper/calibration and
 //   the windowed-mode scan fallback — windowed scans crop to game bounds downstream).
 // - captureWindow(title, expectedSize): a single window source by exact title —
-//   the scan path for fullscreen/borderless Dota. Capturing only the game window
+//   the scan FALLBACK for fullscreen/borderless Dota (the primary path is
+//   cached-window-capture-service, which avoids the per-scan getSources
+//   enumeration measured at 730-1075ms). Capturing only the game window
 //   avoids the full-display Windows Graphics Capture session that hitches the game
 //   (and briefly the cursor) every auto-rescan tick. Returns null when the source
 //   is missing or the captured size deviates from expectedSize (e.g. windowed mode,

--- a/src/renderer/overlay/src/capture-agent.ts
+++ b/src/renderer/overlay/src/capture-agent.ts
@@ -1,0 +1,165 @@
+import type { IpcOnMap } from '@shared/ipc/api'
+import {
+  CAPTURE_STREAM_MAX_FPS,
+  CAPTURE_FIRST_FRAME_TIMEOUT_MS,
+} from '@shared/constants/thresholds'
+
+// @DEV-GUIDE: Renderer half of the cached-source scan capture (see
+// cached-window-capture-service.ts in main for the why + fallback story).
+// Main resolves the game window's desktopCapturer source id once and asks this
+// agent for frames; the agent keeps a getUserMedia(chromeMediaSourceId) stream
+// alive between scans so each grab costs one canvas draw instead of a full
+// getSources enumeration (~800ms saved per scan).
+//
+// Runs OUTSIDE React (initialized from main.tsx): pure IPC + DOM, no UI. The
+// video element is never attached to the document — Chromium delivers
+// MediaStream frames to detached elements just fine, and the overlay stays
+// visually untouched. drawImage + getImageData normalizes whatever pixel
+// format WGC delivers (BGRA GPU textures) into tightly-packed RGBA; main
+// drops the alpha channel.
+//
+// Requests are serialized through a promise chain: interleaved frame/stop
+// messages (e.g. a manual rescan racing the auto-rescan tick) each see a
+// consistent stream state. Every failure answers ok:false so main falls back
+// to its getSources path; a dying track (game window closed/recreated on
+// resolution change) reports capture:sessionEnded so main re-resolves the id.
+
+/** Electron's legacy desktop-capture getUserMedia constraints (not in lib.dom). */
+interface DesktopCaptureConstraints {
+  audio: false
+  video: {
+    mandatory: {
+      chromeMediaSource: 'desktop'
+      chromeMediaSourceId: string
+      maxWidth: number
+      maxHeight: number
+      maxFrameRate: number
+    }
+  }
+}
+
+let stream: MediaStream | null = null
+let video: HTMLVideoElement | null = null
+let activeSourceId: string | null = null
+let canvas: HTMLCanvasElement | null = null
+
+/** Serializes frame/stop handling so stream state never races. */
+let opChain: Promise<void> = Promise.resolve()
+function enqueue(op: () => Promise<void> | void): void {
+  opChain = opChain.then(op).catch(() => undefined)
+}
+
+function handleTrackEnded(): void {
+  enqueue(() => {
+    stopStream()
+    window.electronApi.send('capture:sessionEnded')
+  })
+}
+
+function stopStream(): void {
+  if (stream) {
+    for (const track of stream.getTracks()) {
+      track.removeEventListener('ended', handleTrackEnded)
+      track.stop()
+    }
+  }
+  if (video) {
+    video.srcObject = null
+  }
+  stream = null
+  video = null
+  activeSourceId = null
+}
+
+async function startStream(req: IpcOnMap['capture:frame']): Promise<void> {
+  stopStream()
+  const constraints: DesktopCaptureConstraints = {
+    audio: false,
+    video: {
+      mandatory: {
+        chromeMediaSource: 'desktop',
+        chromeMediaSourceId: req.sourceId,
+        maxWidth: req.maxWidth,
+        maxHeight: req.maxHeight,
+        maxFrameRate: CAPTURE_STREAM_MAX_FPS,
+      },
+    },
+  }
+  const newStream = await navigator.mediaDevices.getUserMedia(
+    constraints as unknown as MediaStreamConstraints,
+  )
+  const newVideo = document.createElement('video')
+  newVideo.muted = true
+  newVideo.srcObject = newStream
+  try {
+    await newVideo.play()
+    // Wait for an actual composited frame — videoWidth is 0 until then, and
+    // the very first WGC session start is where the known ~300ms
+    // "Failed to start capture" retry quirk lives.
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('Timed out waiting for first capture frame')),
+        CAPTURE_FIRST_FRAME_TIMEOUT_MS,
+      )
+      newVideo.requestVideoFrameCallback(() => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+  } catch (error) {
+    newVideo.srcObject = null
+    for (const track of newStream.getTracks()) track.stop()
+    throw error
+  }
+  for (const track of newStream.getTracks()) {
+    track.addEventListener('ended', handleTrackEnded)
+  }
+  stream = newStream
+  video = newVideo
+  activeSourceId = req.sourceId
+}
+
+async function handleFrameRequest(req: IpcOnMap['capture:frame']): Promise<void> {
+  try {
+    if (video === null || activeSourceId !== req.sourceId) {
+      await startStream(req)
+    }
+    const v = video
+    if (!v || v.videoWidth === 0 || v.videoHeight === 0) {
+      throw new Error('Capture stream has no frame')
+    }
+    canvas ??= document.createElement('canvas')
+    canvas.width = v.videoWidth
+    canvas.height = v.videoHeight
+    const ctx = canvas.getContext('2d', { willReadFrequently: true })
+    if (!ctx) {
+      throw new Error('Canvas 2d context unavailable')
+    }
+    ctx.drawImage(v, 0, 0)
+    const image = ctx.getImageData(0, 0, canvas.width, canvas.height)
+    window.electronApi.send('capture:frameResult', {
+      requestId: req.requestId,
+      ok: true,
+      width: image.width,
+      height: image.height,
+      data: new Uint8Array(image.data.buffer, image.data.byteOffset, image.data.byteLength),
+    })
+  } catch (error) {
+    stopStream()
+    window.electronApi.send('capture:frameResult', {
+      requestId: req.requestId,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/** Idempotent per page load; called once from main.tsx (outside React). */
+export function initCaptureAgent(): void {
+  window.electronApi.on('capture:frame', (req) => {
+    enqueue(() => handleFrameRequest(req))
+  })
+  window.electronApi.on('capture:stop', () => {
+    enqueue(() => stopStream())
+  })
+}

--- a/src/renderer/overlay/src/main.tsx
+++ b/src/renderer/overlay/src/main.tsx
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom/client'
 import './i18n'
 import App from './App'
 import './globals.css'
+import { initCaptureAgent } from './capture-agent'
+
+// Cached-source scan capture lives outside React — main drives it over IPC
+initCaptureAgent()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/shared/constants/thresholds.ts
+++ b/src/shared/constants/thresholds.ts
@@ -77,6 +77,28 @@ export const REPLAY_CLOCK_REWIND_THRESHOLD_S = 10
 // slot) or a long-lived in-game overlay must not stall updates indefinitely.
 export const RESCAN_GUARD_MAX_CONSECUTIVE_REJECTIONS = 3
 
+// Cached-source game window capture (cached-window-capture-service.ts + the
+// overlay renderer's capture-agent.ts). desktopCapturer.getSources() thumbnails
+// EVERY open window to deliver one frame (measured 730-1075ms/scan, ~85% of
+// scan latency), so scans instead grab frames from a persistent getUserMedia
+// stream of the game window; getSources runs once per session (thumbnail-free)
+// only to resolve the window's source id.
+// Stream frame-rate cap: scans run at most every ~1.5s, so a frame up to
+// 1/10s stale is irrelevant while the capture stays cheap between scans.
+export const CAPTURE_STREAM_MAX_FPS = 10
+// Main-side wait for the renderer's frame response. Covers a cold stream start
+// (getUserMedia + the known ~300ms WGC first-attempt failure) with room to
+// spare; on expiry the scan falls back to the getSources path (~1s).
+export const CAPTURE_FRAME_TIMEOUT_MS = 4_000
+// Renderer-side wait for the FIRST frame after a stream starts. Must stay
+// below CAPTURE_FRAME_TIMEOUT_MS so the error response beats the main-side
+// timeout (a timed-out request ignores late responses).
+export const CAPTURE_FIRST_FRAME_TIMEOUT_MS = 3_000
+// No frame requested for this long -> the draft is over; stop the renderer
+// stream so the WGC capture session doesn't run for the whole match. The
+// cached source id survives (restarting the stream is cheap).
+export const CAPTURE_IDLE_STOP_MS = 30_000
+
 // Per-player draft score: score = clamp01(meanWinrate + weight * Σ clamped pair lifts).
 // MAX_PAIR_DELTA caps a single pair's contribution so one outlier synergy row
 // cannot dominate the whole score.

--- a/src/shared/ipc/api.ts
+++ b/src/shared/ipc/api.ts
@@ -142,6 +142,21 @@ export interface IpcInvokeMap {
 
 // Send (fire-and-forget) channels from renderer to main
 export interface IpcSendMap {
+  // Cached-source capture responses (overlay capture-agent -> main). Handled
+  // inside cached-window-capture-service (request/response correlation lives
+  // there), NOT in src/main/ipc/. data is tightly-packed RGBA at the captured
+  // size (getImageData output — no stride padding, alpha always 255).
+  'capture:frameResult': {
+    requestId: number
+    ok: boolean
+    width?: number
+    height?: number
+    data?: Uint8Array
+    error?: string
+  }
+  // The capture track died (game window closed/recreated, e.g. resolution
+  // change) — main must drop the cached source id and re-resolve.
+  'capture:sessionEnded': void
   'scraper:start': void
   'scraper:startLiquipedia': void
   'overlay:close': void
@@ -163,6 +178,19 @@ export interface IpcSendMap {
 // Scraper/theme/i18n/update state intentionally has NO push channels here —
 // it flows through the @zubridge-synced AppStore.
 export interface IpcOnMap {
+  // Cached-source capture requests (main -> overlay capture-agent): grab one
+  // frame of the desktopCapturer source `sourceId` from a persistent
+  // getUserMedia stream and answer on 'capture:frameResult' with the same
+  // requestId. max* bound the stream resolution (never upscaled).
+  'capture:frame': {
+    requestId: number
+    sourceId: string
+    maxWidth: number
+    maxHeight: number
+  }
+  // Stop the capture stream (scans idle — draft over). The cached source id
+  // in main stays valid; the next request restarts the stream.
+  'capture:stop': void
   'overlay:data': OverlayDataPayload
   'overlay:hotkey': { action: 'scan' | 'rescan' }
   'ml:scanResults': {

--- a/tests/unit/main/services/cached-window-capture-service.test.ts
+++ b/tests/unit/main/services/cached-window-capture-service.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  CAPTURE_FRAME_TIMEOUT_MS,
+  CAPTURE_IDLE_STOP_MS,
+} from '@shared/constants/thresholds'
+
+// Mock electron's desktopCapturer + ipcMain
+const mockGetSources = vi.fn()
+const ipcListeners = new Map<string, (...args: unknown[]) => void>()
+vi.mock('electron', () => ({
+  desktopCapturer: {
+    getSources: (...args: unknown[]) => mockGetSources(...args),
+  },
+  ipcMain: {
+    on: (channel: string, listener: (...args: unknown[]) => void) => {
+      ipcListeners.set(channel, listener)
+    },
+    removeListener: (channel: string) => {
+      ipcListeners.delete(channel)
+    },
+  },
+}))
+
+vi.mock('electron-log/main', () => ({
+  default: {
+    scope: () => ({
+      debug: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+}))
+
+import { createCachedWindowCaptureService } from '../../../../src/main/services/cached-window-capture-service'
+import type { CachedWindowCaptureService } from '../../../../src/main/services/cached-window-capture-service'
+import type { WindowManager } from '../../../../src/main/services/window-manager'
+
+/** RGBA frame: every pixel R=30, G=20, B=10, A=255. */
+function makeRgbaFrame(width: number, height: number): Uint8Array {
+  const data = new Uint8Array(width * height * 4)
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = 30
+    data[i + 1] = 20
+    data[i + 2] = 10
+    data[i + 3] = 255
+  }
+  return data
+}
+
+interface SentFrameRequest {
+  requestId: number
+  sourceId: string
+  maxWidth: number
+  maxHeight: number
+}
+
+describe('CachedWindowCaptureService', () => {
+  const mockSend = vi.fn()
+  let overlayDestroyed = false
+  let overlayExists = true
+  const windowManager = {
+    getOverlayWindow: () =>
+      overlayExists
+        ? { isDestroyed: () => overlayDestroyed, webContents: { send: mockSend } }
+        : null,
+  } as unknown as WindowManager
+
+  let service: CachedWindowCaptureService
+
+  /** Wires webContents.send('capture:frame') to synchronously answer like the renderer. */
+  function autoRespond(
+    responder: (req: SentFrameRequest) => Record<string, unknown> | null,
+  ): void {
+    mockSend.mockImplementation((channel: string, req: SentFrameRequest) => {
+      if (channel !== 'capture:frame') return
+      const reply = responder(req)
+      if (reply) {
+        ipcListeners.get('capture:frameResult')?.({}, { requestId: req.requestId, ...reply })
+      }
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ipcListeners.clear()
+    overlayDestroyed = false
+    overlayExists = true
+    mockGetSources.mockResolvedValue([
+      { id: 'window:1:0', name: 'Discord' },
+      { id: 'window:2:0', name: 'Dota 2' },
+    ])
+    service = createCachedWindowCaptureService(windowManager)
+  })
+
+  afterEach(() => {
+    service.dispose()
+    vi.useRealTimers()
+  })
+
+  it('resolves the source id thumbnail-free, grabs a frame, and converts RGBA to RGB', async () => {
+    autoRespond(() => ({ ok: true, width: 2, height: 2, data: makeRgbaFrame(2, 2) }))
+
+    const raw = await service.captureFrame('Dota 2', { width: 2, height: 2 })
+
+    expect(mockGetSources).toHaveBeenCalledWith({
+      types: ['window'],
+      thumbnailSize: { width: 0, height: 0 },
+      fetchWindowIcons: false,
+    })
+    const frameRequest = mockSend.mock.calls.find(([c]) => c === 'capture:frame')
+    expect(frameRequest?.[1]).toMatchObject({
+      sourceId: 'window:2:0',
+      maxWidth: 2,
+      maxHeight: 2,
+    })
+    expect(raw).not.toBeNull()
+    expect(raw?.width).toBe(2)
+    expect(raw?.height).toBe(2)
+    expect(raw?.data.length).toBe(2 * 2 * 3)
+    // RGBA (30,20,10,255) comes out as RGB (30,20,10) — alpha dropped
+    expect(raw?.data[0]).toBe(30)
+    expect(raw?.data[1]).toBe(20)
+    expect(raw?.data[2]).toBe(10)
+  })
+
+  it('reuses the cached source id — getSources runs once across scans', async () => {
+    autoRespond(() => ({ ok: true, width: 2, height: 2, data: makeRgbaFrame(2, 2) }))
+
+    await service.captureFrame('Dota 2', { width: 2, height: 2 })
+    await service.captureFrame('Dota 2', { width: 2, height: 2 })
+
+    expect(mockGetSources).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when the window title is not among the sources', async () => {
+    mockGetSources.mockResolvedValue([{ id: 'window:1:0', name: 'Discord' }])
+    expect(await service.captureFrame('Dota 2', { width: 2, height: 2 })).toBeNull()
+    expect(mockSend).not.toHaveBeenCalledWith('capture:frame', expect.anything())
+  })
+
+  it('returns null without touching getSources when the overlay window is gone', async () => {
+    overlayExists = false
+    expect(await service.captureFrame('Dota 2', { width: 2, height: 2 })).toBeNull()
+    expect(mockGetSources).not.toHaveBeenCalled()
+  })
+
+  it('invalidates the cached id on a renderer error and re-resolves next scan', async () => {
+    autoRespond(() => ({ ok: false, error: 'stream died' }))
+    expect(await service.captureFrame('Dota 2', { width: 2, height: 2 })).toBeNull()
+    // Failure sends capture:stop to the renderer
+    expect(mockSend).toHaveBeenCalledWith('capture:stop')
+
+    autoRespond(() => ({ ok: true, width: 2, height: 2, data: makeRgbaFrame(2, 2) }))
+    expect(await service.captureFrame('Dota 2', { width: 2, height: 2 })).not.toBeNull()
+    expect(mockGetSources).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null when the captured size deviates from the expected size', async () => {
+    autoRespond(() => ({ ok: true, width: 8, height: 8, data: makeRgbaFrame(8, 8) }))
+    expect(await service.captureFrame('Dota 2', { width: 2, height: 2 })).toBeNull()
+  })
+
+  it('accepts a size within the 2px tolerance', async () => {
+    autoRespond(() => ({ ok: true, width: 4, height: 3, data: makeRgbaFrame(4, 3) }))
+    const raw = await service.captureFrame('Dota 2', { width: 3, height: 2 })
+    expect(raw?.width).toBe(4)
+  })
+
+  it('times out and returns null when the renderer never responds', async () => {
+    vi.useFakeTimers()
+    autoRespond(() => null)
+
+    const promise = service.captureFrame('Dota 2', { width: 2, height: 2 })
+    await vi.advanceTimersByTimeAsync(CAPTURE_FRAME_TIMEOUT_MS + 1)
+
+    expect(await promise).toBeNull()
+  })
+
+  it('drops the cached id when the renderer reports the session ended', async () => {
+    autoRespond(() => ({ ok: true, width: 2, height: 2, data: makeRgbaFrame(2, 2) }))
+    await service.captureFrame('Dota 2', { width: 2, height: 2 })
+
+    ipcListeners.get('capture:sessionEnded')?.({})
+
+    await service.captureFrame('Dota 2', { width: 2, height: 2 })
+    expect(mockGetSources).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops the renderer stream after the idle period', async () => {
+    vi.useFakeTimers()
+    autoRespond(() => ({ ok: true, width: 2, height: 2, data: makeRgbaFrame(2, 2) }))
+    await service.captureFrame('Dota 2', { width: 2, height: 2 })
+
+    expect(mockSend).not.toHaveBeenCalledWith('capture:stop')
+    await vi.advanceTimersByTimeAsync(CAPTURE_IDLE_STOP_MS + 1)
+    expect(mockSend).toHaveBeenCalledWith('capture:stop')
+  })
+
+  it('a scan within the idle period re-arms the idle stop', async () => {
+    vi.useFakeTimers()
+    autoRespond(() => ({ ok: true, width: 2, height: 2, data: makeRgbaFrame(2, 2) }))
+
+    await service.captureFrame('Dota 2', { width: 2, height: 2 })
+    await vi.advanceTimersByTimeAsync(CAPTURE_IDLE_STOP_MS - 1000)
+    await service.captureFrame('Dota 2', { width: 2, height: 2 })
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(mockSend).not.toHaveBeenCalledWith('capture:stop')
+  })
+
+  it('dispose unregisters the ipc listeners', () => {
+    expect(ipcListeners.has('capture:frameResult')).toBe(true)
+    expect(ipcListeners.has('capture:sessionEnded')).toBe(true)
+    service.dispose()
+    expect(ipcListeners.has('capture:frameResult')).toBe(false)
+    expect(ipcListeners.has('capture:sessionEnded')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Replaces the per-scan `desktopCapturer.getSources()` call with a cached-source capture path for fullscreen/borderless Dota:

- **`cached-window-capture-service.ts`** (main, new): resolves the Dota window's source id **once per session** via a thumbnail-free `getSources` call, then requests frames from the overlay renderer over new typed `capture:*` IPC channels (request/response correlation with a 4s timeout lives in the service, which is why these send channels are handled there rather than in `src/main/ipc/`). After 30s without a scan it stops the renderer stream so the WGC capture session doesn't outlive the draft.
- **`capture-agent.ts`** (overlay renderer, new, outside React): keeps a persistent `getUserMedia(chromeMediaSourceId)` stream (max 10fps) on a detached video element; each request draws the latest frame to a canvas and ships tightly-packed RGBA to main — the canvas normalizes WGC's BGRA output, so main only drops alpha. Requests are serialized through a promise chain so interleaved frame/stop messages never race stream state.
- **`scan-trigger-service.ts`**: capture cascade is now cached-source → `captureWindow` (per-scan getSources) → full-display `capture()`. Windowed mode is untouched.

## Why

Live instrumentation of a full draft showed `getSources()` costs **730–1075ms per scan** (1775ms cold) because Chromium thumbnails all ~16 open windows to deliver the one Dota frame — ~85% of total scan latency in the GSI turn-driven auto-rescan flow (scans every ~7s).

**Measured against the live game window** (Playwright launch of the built app, overlay activated, initial scan + two rescans over the real Dota 2 window at 2560x1440):

| | before | after |
|---|---|---|
| warm capture | 730–1075ms | **~150ms grab + ~25ms convert** |
| cold (once/session) | 1775ms | 807ms resolve + 586ms stream start |
| WGC "Failed to start capture" stderr noise | every scan | once per session |

## Fallback story

Every failure returns null and the scan falls through to the proven getSources path: source not found, renderer error/timeout, captured-size drift beyond 2px (windowed mode / resolution change), or the capture track dying when the game window is recreated — the renderer reports `capture:sessionEnded` and the id is re-resolved next scan.

## Reviewer notes

- No child-process capture (CLAUDE.md invariant intact); no CSP or contextIsolation changes — the agent is plain page code using the existing typed `electronApi` bridge.
- `thumbnailSize: {0,0}` getSources is NOT free (~800ms measured) — the win is doing it once, not per scan.
- 12 new unit tests cover resolve-once caching, RGBA→RGB conversion, every invalidation path, timeout, and idle-stop re-arming. Full suite: 562 passing; typecheck + lint + electron-vite build clean.
- Still to confirm in a real draft (can only be seen in person): no WGC yellow border around the game window from the persistent session, and no game hitching from the 10fps stream. The `Captured game window (cached source)` debug log carries `grabMs`/`convertMs`/`resolveMs` for direct comparison with the old `getSourcesMs` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)