### PR TITLE
feat(stream): GSI slot-to-row correlation for spectate/replay name placement

### DIFF
--- a/src/core/domain/slot-row-correlation.ts
+++ b/src/core/domain/slot-row-correlation.ts
@@ -1,0 +1,260 @@
+import {
+  PLAYER_CARD_DIFF_THRESHOLD,
+  SLOT_MAP_EVENT_SLACK_BEFORE_MS,
+  SLOT_MAP_EVENT_SLACK_AFTER_MS,
+} from '@shared/constants/thresholds'
+import { meanAbsDiff } from './model-pick-detection'
+
+// @DEV-GUIDE: GSI slot <-> scan row correlation for SPECTATE/REPLAY sessions.
+// Problem: in spectate, GSI reports players by team_slot but that order does NOT
+// match the draft screen's visual row order, and no GSI field derives the mapping
+// (verified empirically: not team_slot, not raw playerN key order, not player_slot;
+// the abilities/draft GSI sections are empty during hero selection). Without the
+// mapping, player names/models land on wrong board rows.
+// Mechanism: correlate GSI hero-model pick events with player-card pixel changes.
+// - Each of the 10 player cards (heroes_coords) shows pixel-static "NO HERO" art
+//   until that row's player drafts a model, then permanently switches to ANIMATED
+//   hero art. Diffing a card against its initial-scan baseline detects the switch
+//   without any image recognition (same principle as model-pick-detection).
+// - When GSI says slot S gained a hero in the same time window that card row R
+//   first read changed, S<->R. Mappings accumulate per draft (sticky) and
+//   ambiguous multi-pick windows resolve by elimination.
+// Safeguards:
+// - Two-scan persistence before a card counts as changed (hover tooltips fake a
+//   change for one capture).
+// - A row is only usable once it has read EQUAL to its baseline at least once
+//   (baselineVerified): a card that already showed a hero at initial-scan time
+//   has an animated baseline that never compares clean — such rows would read
+//   "changed" forever and must not correlate with anything.
+// - Replay rewinds revert cards to NO HERO (reads equal to baseline again) and
+//   revert GSI heroes to null; both sides re-fire on the re-pick, giving repeat
+//   chances. Committed mappings are identity facts and never revert.
+// - Commits require the event's match window to be CLOSED (no future row can
+//   join) and mutual uniqueness (the row isn't claimed by another event).
+// - GSI teams are authoritative (team2 -> rows 0-4, team3 -> rows 5-9), so
+//   candidates are restricted to the event's team half.
+
+/** One normalized player-card crop: raw RGB bytes at PLAYER_CARD_COMPARE_SIZE². */
+export interface PlayerCardCapture {
+  /** Scan row 0-9 (heroes_coords hero_order: 0-4 radiant column, 5-9 dire). */
+  row: number
+  tile: Uint8Array
+}
+
+export interface CardRowState {
+  row: number
+  /**
+   * The row has compared EQUAL to its baseline at least once, proving the
+   * baseline is its static NO HERO art. Rows that never verify (a hero was
+   * already drafted when the baseline was captured) are excluded from
+   * correlation — their animated baseline reads "changed" on every scan.
+   */
+  baselineVerified: boolean
+  status: 'static' | 'pending' | 'changed'
+  /** Wall-clock ms when the current change was FIRST read (set on pending,
+   * kept through changed, cleared when the card reads static again). */
+  firstChangedAtMs: number | null
+}
+
+/** GSI reported this slot gained a hero model at atMs (wall clock). */
+export interface GsiHeroEvent {
+  /** GSI slot index 0-9 (team-correct, within-team order unknown). */
+  slot: number
+  npcName: string
+  atMs: number
+}
+
+export interface SlotRowMapping {
+  gsiSlot: number
+  scanRow: number
+}
+
+export function initialCardRows(rows: number[]): CardRowState[] {
+  return rows.map((row) => ({
+    row,
+    baselineVerified: false,
+    status: 'static' as const,
+    firstChangedAtMs: null,
+  }))
+}
+
+export interface CardChangeResult {
+  rows: CardRowState[]
+  /** Rows that newly CONFIRMED changed this scan, with their measured diff. */
+  newlyChanged: Array<{ row: number; diff: number }>
+}
+
+/**
+ * Advance per-row change state from one scan's card captures. Rows missing
+ * from `current` (failed crops) keep their previous state.
+ */
+export function detectCardChanges(input: {
+  baselines: PlayerCardCapture[]
+  current: PlayerCardCapture[]
+  rows: CardRowState[]
+  nowMs: number
+  threshold?: number
+}): CardChangeResult {
+  const threshold = input.threshold ?? PLAYER_CARD_DIFF_THRESHOLD
+  const baselineByRow = new Map(input.baselines.map((b) => [b.row, b.tile]))
+  const currentByRow = new Map(input.current.map((c) => [c.row, c.tile]))
+
+  const newlyChanged: Array<{ row: number; diff: number }> = []
+  const rows = input.rows.map((state) => {
+    const baseline = baselineByRow.get(state.row)
+    const tile = currentByRow.get(state.row)
+    if (!baseline || !tile) return state
+
+    const diff = meanAbsDiff(baseline, tile)
+    if (diff <= threshold) {
+      // Reads as the baseline NO HERO art: verifies the baseline, and reverts
+      // any change (replay rewound past the pick, or a pending flicker).
+      return {
+        ...state,
+        baselineVerified: true,
+        status: 'static' as const,
+        firstChangedAtMs: null,
+      }
+    }
+    if (state.status === 'static') {
+      return { ...state, status: 'pending' as const, firstChangedAtMs: input.nowMs }
+    }
+    if (state.status === 'pending') {
+      newlyChanged.push({ row: state.row, diff })
+      return { ...state, status: 'changed' as const }
+    }
+    return state
+  })
+
+  return { rows, newlyChanged }
+}
+
+export interface CorrelationResult {
+  mappings: SlotRowMapping[]
+  /** Mappings committed by THIS step (subset of mappings). */
+  newMappings: SlotRowMapping[]
+  /** Surviving unmapped events (latest per slot, dead events pruned). */
+  events: GsiHeroEvent[]
+  /** Slots whose event was dropped as unmatchable (no row ever changed in
+   * window — e.g. the pick was already baked into the baseline). */
+  prunedSlots: number[]
+}
+
+function sameTeam(slot: number, row: number): boolean {
+  return slot < 5 === row < 5
+}
+
+/**
+ * Try to resolve GSI hero events against changed card rows. Pure step function:
+ * call after every scan and/or GSI update with the accumulated state.
+ */
+export function correlateSlotRows(input: {
+  events: GsiHeroEvent[]
+  rows: CardRowState[]
+  mappings: SlotRowMapping[]
+  nowMs: number
+  slackBeforeMs?: number
+  slackAfterMs?: number
+}): CorrelationResult {
+  const slackBefore = input.slackBeforeMs ?? SLOT_MAP_EVENT_SLACK_BEFORE_MS
+  const slackAfter = input.slackAfterMs ?? SLOT_MAP_EVENT_SLACK_AFTER_MS
+
+  const mappings = [...input.mappings]
+  const newMappings: SlotRowMapping[] = []
+  const mappedSlots = new Set(mappings.map((m) => m.gsiSlot))
+  const mappedRows = new Set(mappings.map((m) => m.scanRow))
+
+  // Latest event per still-unmapped slot (rewind re-picks supersede older events)
+  const eventBySlot = new Map<number, GsiHeroEvent>()
+  for (const event of input.events) {
+    if (mappedSlots.has(event.slot)) continue
+    const prev = eventBySlot.get(event.slot)
+    if (!prev || event.atMs >= prev.atMs) eventBySlot.set(event.slot, event)
+  }
+
+  const eligibleRow = (r: CardRowState): boolean =>
+    r.status === 'changed' && r.baselineVerified && !mappedRows.has(r.row)
+  const inWindow = (e: GsiHeroEvent, r: CardRowState): boolean =>
+    r.firstChangedAtMs !== null &&
+    r.firstChangedAtMs >= e.atMs - slackBefore &&
+    r.firstChangedAtMs <= e.atMs + slackAfter
+  const windowClosed = (e: GsiHeroEvent): boolean => input.nowMs > e.atMs + slackAfter
+
+  function commit(gsiSlot: number, scanRow: number): void {
+    const mapping = { gsiSlot, scanRow }
+    mappings.push(mapping)
+    newMappings.push(mapping)
+    mappedSlots.add(gsiSlot)
+    mappedRows.add(scanRow)
+    eventBySlot.delete(gsiSlot)
+  }
+
+  let progress = true
+  while (progress) {
+    progress = false
+    const unmappedEvents = [...eventBySlot.values()]
+
+    // Rule 1: an event whose CLOSED window contains exactly one eligible row,
+    // where that row is claimed by no other event — commit.
+    for (const event of unmappedEvents) {
+      if (mappedSlots.has(event.slot) || !windowClosed(event)) continue
+      const candidates = input.rows.filter(
+        (r) => eligibleRow(r) && sameTeam(event.slot, r.row) && inWindow(event, r),
+      )
+      if (candidates.length !== 1) continue
+      const row = candidates[0]
+      const claims = [...eventBySlot.values()].filter(
+        (other) => sameTeam(other.slot, row.row) && inWindow(other, row),
+      )
+      if (claims.length !== 1) continue
+      commit(event.slot, row.row)
+      progress = true
+    }
+
+    // Rule 2: per-team elimination — when a team is down to exactly one
+    // unmapped event and one eligible row, they must belong together even if
+    // the timing window misses (late confirmation, tooltip retry storms).
+    // Both sides must be past their arrival windows: the event's window must
+    // be closed (its own row can no longer show up and make this ambiguous)
+    // and the row must be older than the GSI lag allowance (its own event can
+    // no longer be in flight).
+    for (const teamStart of [0, 5]) {
+      const teamEvents = [...eventBySlot.values()].filter(
+        (e) => e.slot >= teamStart && e.slot < teamStart + 5,
+      )
+      const teamRows = input.rows.filter(
+        (r) => eligibleRow(r) && r.row >= teamStart && r.row < teamStart + 5,
+      )
+      if (teamEvents.length !== 1 || teamRows.length !== 1) continue
+      const [event] = teamEvents
+      const [row] = teamRows
+      if (!windowClosed(event)) continue
+      if (row.firstChangedAtMs === null || input.nowMs <= row.firstChangedAtMs + slackBefore) {
+        continue
+      }
+      commit(event.slot, row.row)
+      progress = true
+    }
+  }
+
+  // Prune events that can never match: window long closed (2x grace so a row
+  // confirming late can still arrive) and NO eligible same-team row left at all
+  // (in-window or not — an out-of-window row keeps the event alive for Rule 2).
+  // Typical cause: the pick happened before the baseline capture, so its card
+  // change is baked into the baseline. Keeping such events would block Rule 2.
+  const prunedSlots: number[] = []
+  const events: GsiHeroEvent[] = []
+  for (const event of eventBySlot.values()) {
+    const expired = input.nowMs > event.atMs + 2 * slackAfter
+    const possibleRows = input.rows.filter(
+      (r) => eligibleRow(r) && sameTeam(event.slot, r.row),
+    )
+    if (expired && possibleRows.length === 0) {
+      prunedSlots.push(event.slot)
+    } else {
+      events.push(event)
+    }
+  }
+
+  return { mappings, newMappings, events, prunedSlots }
+}

--- a/src/core/domain/stream-board.ts
+++ b/src/core/domain/stream-board.ts
@@ -58,12 +58,20 @@ export interface StreamBoardBuildInput {
   pickEvents?: PickEvent[]
   /** Model -> player attribution from turn timing (playing mode; GSI covers spectate). */
   modelAssignments?: Array<{ poolHeroOrder: number; playerIndex: number }>
+  /**
+   * Learned GSI slot -> scan row mappings (spectate/replay). GSI's within-team
+   * slot order does not match the draft screen's row order, so in spectate mode
+   * GSI names/models are ONLY placed on rows with a committed mapping — an
+   * unmapped row shows no name rather than a probably-wrong one.
+   */
+  slotRowMappings?: Array<{ gsiSlot: number; scanRow: number }>
 }
 
 const EMPTY_GSI: StreamGsiInfo = {
   connected: false,
   gamePhase: null,
   clockTime: null,
+  spectating: false,
   playerNames: [],
   playerModels: [],
 }
@@ -141,8 +149,16 @@ function buildPlayerRows(
   heroRows: StreamHeroRow[],
   initialPayload: OverlayDataPayload,
   modelAssignments: Array<{ poolHeroOrder: number; playerIndex: number }>,
+  slotRowMappings: Array<{ gsiSlot: number; scanRow: number }>,
 ): StreamPlayerRow[] {
   const selected = latestPayload?.scanData?.selectedAbilities ?? []
+
+  // Spectate: GSI arrays are slot-indexed and the within-team slot order does
+  // NOT match the board's row order — only a correlated mapping may place a
+  // name/model on a row. Playing: the index IS the row (validated team_slot).
+  const slotByRow = new Map(slotRowMappings.map((m) => [m.scanRow, m.gsiSlot]))
+  const gsiSlotForRow = (row: number): number | null =>
+    gsi.spectating ? (slotByRow.get(row) ?? null) : row
 
   // Scan-attributed model per player (playing mode fallback — GSI wins below)
   const assignedByPlayer = new Map<number, StreamPlayerModel>()
@@ -188,12 +204,13 @@ function buildPlayerRows(
           )
         : null
 
-    const gsiModel = gsi.playerModels[playerIndex] ?? null
+    const gsiSlot = gsiSlotForRow(playerIndex)
+    const gsiModel = gsiSlot !== null ? (gsi.playerModels[gsiSlot] ?? null) : null
 
     rows.push({
       playerIndex,
       team: playerIndex < PLAYER_COUNT / 2 ? 'radiant' : 'dire',
-      playerName: gsi.playerNames[playerIndex] ?? null,
+      playerName: gsiSlot !== null ? (gsi.playerNames[gsiSlot] ?? null) : null,
       model: gsiModel
         ? { ...gsiModel, portraitPath: heroIconPath(gsiModel.npcName) }
         : (assignedByPlayer.get(playerIndex) ?? null),
@@ -297,6 +314,7 @@ export function buildStreamBoardState(
       heroes,
       initialPayload,
       input.modelAssignments ?? [],
+      input.slotRowMappings ?? [],
     ),
     panels: buildPanels(latestPayload, pickedNames),
     gsi,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,6 +12,7 @@ import { createStreamServerService } from './services/stream-server-service'
 import { createIconCacheService } from './services/icon-cache-service'
 import { createGsiCfgService } from './services/gsi-cfg-service'
 import { createSpotDetectionService } from './services/spot-detection-service'
+import { createSlotMappingService } from './services/slot-mapping-service'
 import { createScanTriggerService } from './services/scan-trigger-service'
 import { createAutoRescanService } from './services/auto-rescan-service'
 import { createUpdateService } from './services/update-service'
@@ -140,6 +141,7 @@ app.whenReady().then(async () => {
     iconCache,
     () => draftStore.getState().draftTimeline,
     () => draftStore.getState().modelAssignments,
+    () => draftStore.getState().slotRowMappings,
   )
   // Auto "My Spot" from GSI (playing mode) — re-applied after each initial scan
   const spotDetectionService = createSpotDetectionService(
@@ -147,6 +149,8 @@ app.whenReady().then(async () => {
     windowManager,
     streamService,
   )
+  // GSI slot <-> scan row correlation (spectate/replay name placement)
+  const slotMappingService = createSlotMappingService(draftStore, streamService)
   const scanProcessingService = createScanProcessingService(
     draftStore,
     dbService,
@@ -154,6 +158,7 @@ app.whenReady().then(async () => {
     windowManager,
     streamService,
     spotDetectionService,
+    slotMappingService,
   )
   const appHandlers = createAppStoreHandlers(appStore)
   const bridge = createZustandBridge(appStore, { handlers: appHandlers })
@@ -270,6 +275,7 @@ app.whenReady().then(async () => {
     gsiCfgService,
     feedbackService,
     scanTrigger,
+    slotMappingService,
   )
 
   // Streamer view autostart (opt-in setting)

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -28,6 +28,7 @@ import { registerStreamHandlers } from './stream-handlers'
 import { loadApiConfig } from '../services/api-config'
 import type { FeedbackService } from '../services/feedback-service'
 import type { ScanTriggerService } from '../services/scan-trigger-service'
+import type { SlotMappingService } from '../services/slot-mapping-service'
 
 // @DEV-GUIDE: Central IPC handler registration. All renderer↔main communication goes through
 // typed IPC channels following the domain:action naming convention (e.g. 'ml:scan', 'hero:getAll').
@@ -68,6 +69,7 @@ export function registerIpcHandlers(
   gsiCfgService: GsiCfgService,
   feedbackService: FeedbackService,
   scanTrigger: ScanTriggerService,
+  slotMappingService: SlotMappingService,
 ): void {
   logger.info('Registering IPC handlers...')
 
@@ -200,6 +202,7 @@ export function registerIpcHandlers(
       appStore.setState({ overlayActive: false, activeResolution: null, activeResolutionSource: null })
       draftStore.getState().resetSession()
       streamService.onSessionReset()
+      slotMappingService.onSessionReset()
       pendingOverlayData = null
 
       const cp = windowManager.getControlPanelWindow()
@@ -224,6 +227,7 @@ export function registerIpcHandlers(
   ipcMain.on('overlay:reset', () => {
     draftStore.getState().resetSession()
     streamService.onSessionReset()
+    slotMappingService.onSessionReset()
   })
 
   ipcMain.on(

--- a/src/main/services/scan-processing-service.ts
+++ b/src/main/services/scan-processing-service.ts
@@ -28,6 +28,7 @@ export interface ScanProcessingService {
     resolution: string,
     scaleFactor: number,
     modelTiles?: import('@core/domain/model-pick-detection').ModelTileCapture[],
+    playerCardTiles?: import('@core/domain/slot-row-correlation').PlayerCardCapture[],
   ): void
 }
 
@@ -43,6 +44,10 @@ export function createScanProcessingService(
   spotDetection?: Pick<
     import('./spot-detection-service').SpotDetectionService,
     'onInitialScanProcessed'
+  >,
+  slotMapping?: Pick<
+    import('./slot-mapping-service').SlotMappingService,
+    'onCardTiles'
   >,
 ): ScanProcessingService {
   // Enrichment failures must reach the overlay: without this broadcast the renderer's
@@ -60,7 +65,14 @@ export function createScanProcessingService(
   }
 
   return {
-    handleScanResults(results, isInitialScan, resolution, scaleFactor, modelTiles) {
+    handleScanResults(
+      results,
+      isInitialScan,
+      resolution,
+      scaleFactor,
+      modelTiles,
+      playerCardTiles,
+    ) {
       const start = performance.now()
 
       try {
@@ -72,6 +84,11 @@ export function createScanProcessingService(
           broadcastError(`No layout coordinates for resolution: ${resolution}`)
           return
         }
+
+        // Player-card change detection + GSI slot correlation runs on EVERY
+        // capture — the cards are spatially separate from the ability rows, so
+        // the contamination guard's verdict below is irrelevant to them.
+        slotMapping?.onCardTiles(playerCardTiles, isInitialScan)
 
         // While SPECTATING, GSI is the authoritative model-pick source and the
         // spectator draft screen's coordinate offsets make tile diffs garbage

--- a/src/main/services/scan-trigger-service.ts
+++ b/src/main/services/scan-trigger-service.ts
@@ -183,6 +183,10 @@ export function createScanTriggerService(
             heroOrder: t.heroOrder,
             tile: new Uint8Array(t.tile),
           })),
+          result.playerCardTiles?.map((t) => ({
+            row: t.row,
+            tile: new Uint8Array(t.tile),
+          })),
         )
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)

--- a/src/main/services/slot-mapping-service.ts
+++ b/src/main/services/slot-mapping-service.ts
@@ -1,0 +1,190 @@
+import log from 'electron-log/main'
+import type { StoreApi } from 'zustand/vanilla'
+import type { DraftStore } from '../store/draft-store'
+import type { StreamServerService } from './stream-server-service'
+import {
+  initialCardRows,
+  detectCardChanges,
+  correlateSlotRows,
+} from '@core/domain/slot-row-correlation'
+import type {
+  PlayerCardCapture,
+  GsiHeroEvent,
+} from '@core/domain/slot-row-correlation'
+
+// @DEV-GUIDE: Electron-side orchestrator for the GSI slot <-> scan row correlation
+// (spectate/replay player-name placement; the pure logic and the WHY live in
+// core/domain/slot-row-correlation.ts). Responsibilities:
+// - Buffer "slot S gained hero H" events from spectate GSI snapshots (diffing
+//   heroNpcName per slot against the previous snapshot; rewind reverts re-arm).
+//   Events are only collected once card baselines exist — earlier picks are baked
+//   into the baseline and could never match a card change.
+// - Receive every scan's player-card crops (ml-worker captures them alongside the
+//   model tiles) and advance change detection + correlation in DraftStore.
+// - Re-run correlation on GSI snapshots too: commits are time-gated (a match
+//   window must close), so they can become due between scans.
+// All correlation state lives in DraftStore (cleared by resetSession); this
+// service only keeps the per-snapshot hero diff state, reset on matchid change.
+
+const logger = log.scope('slot-mapping')
+
+export interface SlotMappingService {
+  /** Fed by scan-processing-service with every scan's card crops. */
+  onCardTiles(tiles: PlayerCardCapture[] | undefined, isInitialScan: boolean): void
+  /** Clears the per-snapshot GSI diff state (overlay reset / closed). */
+  onSessionReset(): void
+}
+
+export function createSlotMappingService(
+  draftStore: StoreApi<DraftStore>,
+  streamService: StreamServerService,
+): SlotMappingService {
+  /** heroNpcName last seen per GSI slot (null = no hero), for edge detection. */
+  const lastHeroBySlot = new Map<number, string | null>()
+  let lastMatchId: string | null = null
+
+  function runCorrelation(nowMs: number): void {
+    const state = draftStore.getState()
+    if (
+      state.gsiHeroEvents.length === 0 &&
+      state.slotRowMappings.length === 0
+    ) {
+      return
+    }
+    const result = correlateSlotRows({
+      events: state.gsiHeroEvents,
+      rows: state.playerCardRows,
+      mappings: state.slotRowMappings,
+      nowMs,
+    })
+    if (
+      result.newMappings.length === 0 &&
+      result.prunedSlots.length === 0 &&
+      result.events.length === state.gsiHeroEvents.length
+    ) {
+      return
+    }
+    draftStore.setState({
+      gsiHeroEvents: result.events,
+      slotRowMappings: result.mappings,
+    })
+    if (result.prunedSlots.length > 0) {
+      logger.info('Dropped unmatchable GSI hero events', {
+        slots: result.prunedSlots,
+      })
+    }
+    if (result.newMappings.length > 0) {
+      logger.info('GSI slot <-> scan row mapping committed', {
+        newMappings: result.newMappings,
+        total: result.mappings.length,
+      })
+      streamService.refresh()
+    }
+  }
+
+  streamService.onGsiSnapshot((snapshot) => {
+    const nowMs = Date.now()
+
+    // A different matchid is a different draft — old hero edges, baselines,
+    // events, and mappings are all meaningless for it. Detection stays inert
+    // until the new draft's initial scan captures fresh baselines.
+    if (snapshot.matchId !== null && snapshot.matchId !== lastMatchId) {
+      if (lastMatchId !== null) {
+        lastHeroBySlot.clear()
+        draftStore.setState({
+          playerCardBaselines: [],
+          playerCardRows: [],
+          gsiHeroEvents: [],
+          slotRowMappings: [],
+        })
+        logger.info('New match — slot mapping state cleared', {
+          matchId: snapshot.matchId,
+        })
+      }
+      lastMatchId = snapshot.matchId
+    }
+
+    if (snapshot.players.length > 0) {
+      const haveBaselines =
+        draftStore.getState().playerCardBaselines.length > 0
+      const mappedSlots = new Set(
+        draftStore.getState().slotRowMappings.map((m) => m.gsiSlot),
+      )
+      const newEvents: GsiHeroEvent[] = []
+      for (const player of snapshot.players) {
+        if (player.slotIndex < 0 || player.slotIndex > 9) continue
+        const prev = lastHeroBySlot.get(player.slotIndex) ?? null
+        if (player.heroNpcName !== prev) {
+          lastHeroBySlot.set(player.slotIndex, player.heroNpcName)
+          // Only a gained hero is an event; a hero going null is a replay
+          // rewind — the next re-pick fires a fresh event.
+          if (
+            player.heroNpcName !== null &&
+            haveBaselines &&
+            !mappedSlots.has(player.slotIndex)
+          ) {
+            newEvents.push({
+              slot: player.slotIndex,
+              npcName: player.heroNpcName,
+              atMs: nowMs,
+            })
+          }
+        }
+      }
+      if (newEvents.length > 0) {
+        logger.info('GSI hero events observed', {
+          events: newEvents.map((e) => `${e.slot}=${e.npcName}`),
+        })
+        draftStore.setState({
+          gsiHeroEvents: [...draftStore.getState().gsiHeroEvents, ...newEvents],
+        })
+      }
+    }
+
+    runCorrelation(nowMs)
+  })
+
+  return {
+    onCardTiles(tiles, isInitialScan): void {
+      if (!tiles || tiles.length === 0) return
+      const nowMs = Date.now()
+
+      if (isInitialScan) {
+        // Fresh reference state; row states restart, sticky mappings and
+        // pending events survive (same draft — a manual re-initial-scan
+        // must not forget what is already known).
+        draftStore.setState({
+          playerCardBaselines: tiles,
+          playerCardRows: initialCardRows(tiles.map((t) => t.row)),
+        })
+        logger.info('Player-card baselines captured', { rows: tiles.length })
+        return
+      }
+
+      const state = draftStore.getState()
+      if (state.playerCardBaselines.length === 0) return
+
+      const detection = detectCardChanges({
+        baselines: state.playerCardBaselines,
+        current: tiles,
+        rows: state.playerCardRows,
+        nowMs,
+      })
+      draftStore.setState({ playerCardRows: detection.rows })
+      if (detection.newlyChanged.length > 0) {
+        logger.info('Player cards changed (model drafted on row)', {
+          rows: detection.newlyChanged.map(
+            (c) => `${c.row} (diff ${Math.round(c.diff)})`,
+          ),
+        })
+      }
+
+      runCorrelation(nowMs)
+    },
+
+    onSessionReset(): void {
+      lastHeroBySlot.clear()
+      lastMatchId = null
+    },
+  }
+}

--- a/src/main/services/stream-server-service.ts
+++ b/src/main/services/stream-server-service.ts
@@ -83,6 +83,7 @@ export function createStreamServerService(
   iconCache: IconCacheService,
   getPickEvents?: () => PickEvent[],
   getModelAssignments?: () => Array<{ poolHeroOrder: number; playerIndex: number }>,
+  getSlotRowMappings?: () => Array<{ gsiSlot: number; scanRow: number }>,
 ): StreamServerService {
   let server: Server | null = null
   let activePort: number | null = null
@@ -171,6 +172,9 @@ export function createStreamServerService(
       connected,
       gamePhase: connected ? (gsiSnapshot?.gamePhase ?? null) : null,
       clockTime: connected ? (gsiSnapshot?.clockTime ?? null) : null,
+      spectating: gsiSnapshot
+        ? gsiSnapshotMode(gsiSnapshot) === 'spectating'
+        : false,
       playerNames,
       playerModels,
     }
@@ -192,6 +196,7 @@ export function createStreamServerService(
       gsi: gsiInfo(),
       pickEvents: getPickEvents?.(),
       modelAssignments: getModelAssignments?.(),
+      slotRowMappings: getSlotRowMappings?.(),
       meta: {
         language: appStore.getState().language,
         appVersion: app.getVersion(),

--- a/src/main/store/draft-store.ts
+++ b/src/main/store/draft-store.ts
@@ -3,6 +3,12 @@ import type { ScanResult } from '@shared/types'
 import type { PickEvent } from '@shared/types/stream'
 import type { IdentifiedHeroModel } from '@core/domain/types'
 import type { ModelTileCapture } from '@core/domain/model-pick-detection'
+import type {
+  PlayerCardCapture,
+  CardRowState,
+  GsiHeroEvent,
+  SlotRowMapping,
+} from '@core/domain/slot-row-correlation'
 
 // @DEV-GUIDE: Ephemeral draft session state, main-process-only (NOT synced via @zubridge).
 // Holds mutable caches and user selections that only exist during an active overlay session:
@@ -43,6 +49,15 @@ export interface DraftSessionSlice {
   modelAssignments: ModelAssignment[]
   /** Attributed pick events (experimental auto-rescan); empty otherwise. */
   draftTimeline: PickEvent[]
+  /** Player cards captured at initial scan (NO HERO reference for the GSI
+   * slot <-> scan row correlation; see slot-row-correlation.ts). */
+  playerCardBaselines: PlayerCardCapture[]
+  /** Per-row card change state (pending/changed + first-seen times). */
+  playerCardRows: CardRowState[]
+  /** Unresolved GSI "slot gained a hero" events (spectate/replay). */
+  gsiHeroEvents: GsiHeroEvent[]
+  /** Committed GSI slot <-> scan row mappings (sticky for the draft). */
+  slotRowMappings: SlotRowMapping[]
 }
 
 /** A picked hero model attributed to the player who drafted it. */
@@ -82,6 +97,10 @@ export function createDraftStore() {
     pickedModelHeroOrders: [],
     modelAssignments: [],
     draftTimeline: [],
+    playerCardBaselines: [],
+    playerCardRows: [],
+    gsiHeroEvents: [],
+    slotRowMappings: [],
 
     // Actions
     resetSession: () =>
@@ -101,6 +120,10 @@ export function createDraftStore() {
         pickedModelHeroOrders: [],
         modelAssignments: [],
         draftTimeline: [],
+        playerCardBaselines: [],
+        playerCardRows: [],
+        gsiHeroEvents: [],
+        slotRowMappings: [],
       }),
 
     selectMySpot: (dbHeroId, heroOrder) =>

--- a/src/main/workers/ml-worker.ts
+++ b/src/main/workers/ml-worker.ts
@@ -11,7 +11,10 @@ import { createOnnxClassifier } from '@core/ml/onnx-classifier'
 import { preprocessBatch, cropTile } from '@core/ml/preprocessing'
 import type { DecodedScreenshot } from '@core/ml/preprocessing'
 import type { ClassifierResult } from '@core/ml/classifier'
-import { MODEL_TILE_COMPARE_SIZE } from '@shared/constants/thresholds'
+import {
+  MODEL_TILE_COMPARE_SIZE,
+  PLAYER_CARD_COMPARE_SIZE,
+} from '@shared/constants/thresholds'
 
 // @DEV-GUIDE: ML Worker thread entry point. Runs as a Node.js worker_thread, spawned by MlService.
 // Handles two operations: init (load ONNX model) and scan (classify ability icons).
@@ -35,7 +38,9 @@ import { MODEL_TILE_COMPARE_SIZE } from '@shared/constants/thresholds'
 // For rescan: processes only the selected-ability slots.
 // Every scan additionally captures the 12 model portrait tiles (models_coords) as
 // normalized raw crops — the scan-processor diffs them against the initial-scan
-// baseline to detect picked models (see core/domain/model-pick-detection.ts).
+// baseline to detect picked models (see core/domain/model-pick-detection.ts) —
+// plus the 10 player cards (heroes_coords) for the GSI slot <-> scan row
+// correlation (see core/domain/slot-row-correlation.ts).
 
 if (!parentPort) {
   throw new Error('ml-worker must run as a worker thread')
@@ -150,17 +155,20 @@ async function handleScan(payload: {
   // Model portrait tiles for picked-model diff detection — captured every scan
   // (~10ms for 12 small crops from the already-decoded bitmap)
   const modelTiles = await captureModelTiles(screenshot, coords)
+  // Player cards for GSI slot <-> scan row correlation — same cost profile
+  const playerCardTiles = await capturePlayerCardTiles(screenshot, coords)
 
   const response: MlWorkerSuccessResponse = {
     status: 'success',
     results,
     isInitialScan,
     modelTiles,
+    playerCardTiles,
   }
-  parentPort!.postMessage(
-    response,
-    modelTiles?.map((t) => t.tile) ?? [],
-  )
+  parentPort!.postMessage(response, [
+    ...(modelTiles?.map((t) => t.tile) ?? []),
+    ...(playerCardTiles?.map((t) => t.tile) ?? []),
+  ])
 }
 
 /** Crop + normalize the 12 model portrait tiles; undefined when unavailable. */
@@ -182,6 +190,38 @@ async function captureModelTiles(
       })
     } catch {
       // Out-of-bounds crop (layout drift) — skip this tile
+    }
+  }
+  return tiles.length > 0 ? tiles : undefined
+}
+
+/**
+ * Crop + normalize the 10 player-card regions. heroes_coords entries carry only
+ * x/y — the shared card dimensions live in heroes_params.
+ */
+async function capturePlayerCardTiles(
+  screenshot: DecodedScreenshot,
+  coords: ResolutionLayout,
+): Promise<{ row: number; tile: ArrayBuffer }[] | undefined> {
+  const heroCoords = coords.heroes_coords
+  const params = coords.heroes_params
+  if (!heroCoords || heroCoords.length === 0) return undefined
+  if (!params || params.width <= 0 || params.height <= 0) return undefined
+
+  const tiles: { row: number; tile: ArrayBuffer }[] = []
+  for (const c of heroCoords) {
+    try {
+      const raw = await cropTile(
+        screenshot,
+        { ...c, width: params.width, height: params.height },
+        PLAYER_CARD_COMPARE_SIZE,
+      )
+      tiles.push({
+        row: c.hero_order,
+        tile: raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength),
+      })
+    } catch {
+      // Out-of-bounds crop (layout drift) — skip this card
     }
   }
   return tiles.length > 0 ? tiles : undefined

--- a/src/renderer/stream/src/demo.ts
+++ b/src/renderer/stream/src/demo.ts
@@ -176,6 +176,7 @@ export function buildDemoState(): StreamBoardState {
       connected: true,
       gamePhase: 'DOTA_GAMERULES_STATE_HERO_SELECTION',
       clockTime: -42,
+      spectating: true,
       playerNames: PLAYER_NAMES,
       playerModels: players.map((p) =>
         p.model ? { npcName: p.model.npcName, displayName: p.model.displayName } : null,

--- a/src/shared/constants/thresholds.ts
+++ b/src/shared/constants/thresholds.ts
@@ -49,6 +49,21 @@ export const MODEL_PICK_DIFF_THRESHOLD = 10
 // resolves in ~1.5s instead of waiting a full turn for the next scheduled scan.
 export const MODEL_PICK_CONFIRM_DELAY_MS = 1_500
 
+// GSI slot <-> scan row correlation via player-card diffing (spectate/replay).
+// The 10 player cards on the draft screen show pixel-static "NO HERO" art until
+// that row's player drafts a model, then switch to ANIMATED hero art — a change
+// that persists against the baseline on every later scan. Cards are normalized
+// to a small square for comparison (same rationale as model tiles; the downscale
+// also absorbs the spectator layout's slight coordinate nudges).
+export const PLAYER_CARD_COMPARE_SIZE = 48
+export const PLAYER_CARD_DIFF_THRESHOLD = 10
+// Matching window between a GSI "slot S gained hero H" event and a card row's
+// first-read-changed time. BEFORE covers GSI lagging the screen (throttle /
+// 10s heartbeat); AFTER covers the scan cadence reaching the changed card
+// (5s replay interval or ~7s turn spacing, plus processing).
+export const SLOT_MAP_EVENT_SLACK_BEFORE_MS = 10_000
+export const SLOT_MAP_EVENT_SLACK_AFTER_MS = 20_000
+
 // Experimental auto-rescan (GSI-driven draft tracking).
 // Fallback auto INITIAL scan: fires this long after the draft clock is first
 // identified (hero selection + clock_time present) when the user hasn't run

--- a/src/shared/types/ml.ts
+++ b/src/shared/types/ml.ts
@@ -61,6 +61,13 @@ export interface MlWorkerSuccessResponse {
    * no models_coords or a tile crop failed.
    */
   modelTiles?: { heroOrder: number; tile: ArrayBuffer }[]
+  /**
+   * Normalized crops of the 10 player cards (heroes_coords regions at
+   * PLAYER_CARD_COMPARE_SIZE²), captured on every scan for the GSI slot <->
+   * scan row correlation (spectate/replay name placement). Buffers are
+   * transferred, not copied. Absent when the layout has no heroes_coords.
+   */
+  playerCardTiles?: { row: number; tile: ArrayBuffer }[]
 }
 
 export interface MlWorkerErrorResponse {

--- a/src/shared/types/stream.ts
+++ b/src/shared/types/stream.ts
@@ -119,9 +119,18 @@ export interface StreamGsiInfo {
   connected: boolean
   gamePhase: string | null
   clockTime: number | null
-  /** Player names by player index 0–9; empty or sparse until GSI reports them. */
+  /**
+   * True when GSI carries allplayers data (spectate/replay). In that case the
+   * arrays below are indexed by GSI SLOT — whose within-team order does NOT
+   * match the draft screen's row order — and entries may only be placed on
+   * board rows through a learned slot->row mapping (see
+   * core/domain/slot-row-correlation.ts). When false (playing), the index is
+   * the scan row directly (local player's team_slot placement is validated).
+   */
+  spectating: boolean
+  /** Player names by slot/player index 0–9; empty or sparse until GSI reports them. */
   playerNames: (string | null)[]
-  /** Picked hero models by player index 0–9 (npcName + resolved display name). */
+  /** Picked hero models by slot/player index 0–9 (npcName + resolved display name). */
   playerModels: ({ npcName: string; displayName: string } | null)[]
 }
 

--- a/tests/unit/core/domain/slot-row-correlation.test.ts
+++ b/tests/unit/core/domain/slot-row-correlation.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect } from 'vitest'
+import {
+  initialCardRows,
+  detectCardChanges,
+  correlateSlotRows,
+} from '@core/domain/slot-row-correlation'
+import type {
+  PlayerCardCapture,
+  CardRowState,
+  GsiHeroEvent,
+  SlotRowMapping,
+} from '@core/domain/slot-row-correlation'
+
+function card(row: number, fill: number, length = 27): PlayerCardCapture {
+  return { row, tile: new Uint8Array(length).fill(fill) }
+}
+
+/** All 10 cards at the given fill, with per-row overrides. */
+function cards(overrides: Record<number, number> = {}): PlayerCardCapture[] {
+  return Array.from({ length: 10 }, (_, row) => card(row, overrides[row] ?? 100))
+}
+
+const ALL_ROWS = Array.from({ length: 10 }, (_, i) => i)
+
+/** Rows after one clean scan (all static, baselines verified). */
+function verifiedRows(): CardRowState[] {
+  return detectCardChanges({
+    baselines: cards(),
+    current: cards(),
+    rows: initialCardRows(ALL_ROWS),
+    nowMs: 0,
+  }).rows
+}
+
+/** Shorthand: run detectCardChanges over a sequence of scans. */
+function scanSequence(
+  rows: CardRowState[],
+  scans: Array<{ overrides: Record<number, number>; nowMs: number }>,
+): CardRowState[] {
+  let state = rows
+  for (const scan of scans) {
+    state = detectCardChanges({
+      baselines: cards(),
+      current: cards(scan.overrides),
+      rows: state,
+      nowMs: scan.nowMs,
+    }).rows
+  }
+  return state
+}
+
+const event = (slot: number, atMs: number, npcName = 'sand_king'): GsiHeroEvent => ({
+  slot,
+  npcName,
+  atMs,
+})
+
+// Slacks used throughout: before 10s, after 20s (defaults from thresholds)
+const AFTER = 20_000
+const BEFORE = 10_000
+
+describe('initialCardRows', () => {
+  it('starts every row static and unverified', () => {
+    const rows = initialCardRows([0, 1])
+    expect(rows).toEqual([
+      { row: 0, baselineVerified: false, status: 'static', firstChangedAtMs: null },
+      { row: 1, baselineVerified: false, status: 'static', firstChangedAtMs: null },
+    ])
+  })
+})
+
+describe('detectCardChanges', () => {
+  it('verifies the baseline when a card reads equal to it', () => {
+    const rows = verifiedRows()
+    expect(rows.every((r) => r.baselineVerified && r.status === 'static')).toBe(true)
+  })
+
+  it('requires two consecutive changed reads to confirm (tooltip guard)', () => {
+    const afterFirst = detectCardChanges({
+      baselines: cards(),
+      current: cards({ 3: 200 }),
+      rows: verifiedRows(),
+      nowMs: 5_000,
+    })
+    expect(afterFirst.newlyChanged).toEqual([])
+    expect(afterFirst.rows[3]).toMatchObject({ status: 'pending', firstChangedAtMs: 5_000 })
+
+    const afterSecond = detectCardChanges({
+      baselines: cards(),
+      current: cards({ 3: 200 }),
+      rows: afterFirst.rows,
+      nowMs: 10_000,
+    })
+    expect(afterSecond.newlyChanged).toEqual([{ row: 3, diff: 100 }])
+    // firstChangedAtMs stays at the FIRST sighting — that is the pick-adjacent time
+    expect(afterSecond.rows[3]).toMatchObject({ status: 'changed', firstChangedAtMs: 5_000 })
+  })
+
+  it('clears a pending flicker that reads static again', () => {
+    const rows = scanSequence(verifiedRows(), [
+      { overrides: { 3: 200 }, nowMs: 5_000 },
+      { overrides: {}, nowMs: 10_000 },
+    ])
+    expect(rows[3]).toMatchObject({ status: 'static', firstChangedAtMs: null })
+  })
+
+  it('reverts a confirmed change when the card matches the baseline again (replay rewind)', () => {
+    const rows = scanSequence(verifiedRows(), [
+      { overrides: { 3: 200 }, nowMs: 5_000 },
+      { overrides: { 3: 210 }, nowMs: 10_000 },
+      { overrides: {}, nowMs: 15_000 },
+    ])
+    expect(rows[3]).toMatchObject({ status: 'static', firstChangedAtMs: null })
+    // ...and a later re-pick starts a fresh change with a fresh timestamp
+    const repicked = scanSequence(rows, [
+      { overrides: { 3: 220 }, nowMs: 60_000 },
+      { overrides: { 3: 230 }, nowMs: 65_000 },
+    ])
+    expect(repicked[3]).toMatchObject({ status: 'changed', firstChangedAtMs: 60_000 })
+  })
+
+  it('never verifies a row that always differs from its baseline (pre-drafted card)', () => {
+    const rows = scanSequence(initialCardRows(ALL_ROWS), [
+      { overrides: { 2: 250 }, nowMs: 5_000 },
+      { overrides: { 2: 240 }, nowMs: 10_000 },
+    ])
+    expect(rows[2]).toMatchObject({ status: 'changed', baselineVerified: false })
+  })
+
+  it('keeps state for rows missing from the capture (failed crop)', () => {
+    const before = scanSequence(verifiedRows(), [
+      { overrides: { 3: 200 }, nowMs: 5_000 },
+      { overrides: { 3: 200 }, nowMs: 10_000 },
+    ])
+    const result = detectCardChanges({
+      baselines: cards(),
+      current: cards({ 3: 200 }).filter((c) => c.row !== 3),
+      rows: before,
+      nowMs: 15_000,
+    })
+    expect(result.rows[3]).toMatchObject({ status: 'changed', firstChangedAtMs: 5_000 })
+  })
+
+  it('ignores sub-threshold noise', () => {
+    const result = detectCardChanges({
+      baselines: cards(),
+      current: cards({ 3: 105 }),
+      rows: verifiedRows(),
+      nowMs: 5_000,
+    })
+    expect(result.rows[3].status).toBe('static')
+  })
+})
+
+describe('correlateSlotRows', () => {
+  /** Verified rows with the given rows confirmed changed at the given times. */
+  function changedRows(changes: Record<number, number>): CardRowState[] {
+    return verifiedRows().map((r) =>
+      changes[r.row] !== undefined
+        ? { ...r, status: 'changed' as const, firstChangedAtMs: changes[r.row] }
+        : r,
+    )
+  }
+
+  it('maps a lone in-window pair once the event window closes', () => {
+    const input = {
+      events: [event(2, 50_000)],
+      rows: changedRows({ 4: 53_000 }),
+      mappings: [] as SlotRowMapping[],
+      nowMs: 50_000 + AFTER + 1,
+    }
+    const result = correlateSlotRows(input)
+    expect(result.newMappings).toEqual([{ gsiSlot: 2, scanRow: 4 }])
+    expect(result.events).toEqual([])
+  })
+
+  it('does not commit while the event window is still open', () => {
+    const result = correlateSlotRows({
+      events: [event(2, 50_000)],
+      rows: changedRows({ 4: 53_000 }),
+      mappings: [],
+      nowMs: 60_000,
+    })
+    expect(result.newMappings).toEqual([])
+    expect(result.events).toHaveLength(1)
+  })
+
+  it('restricts candidates to the event team half', () => {
+    // Dire slot 7 event; only a radiant row changed in window -> no mapping
+    const result = correlateSlotRows({
+      events: [event(7, 50_000)],
+      rows: changedRows({ 4: 53_000 }),
+      mappings: [],
+      nowMs: 50_000 + AFTER + 1,
+    })
+    expect(result.newMappings).toEqual([])
+  })
+
+  it('leaves a simultaneous two-pick window ambiguous', () => {
+    const result = correlateSlotRows({
+      events: [event(1, 50_000), event(2, 51_000)],
+      rows: changedRows({ 3: 52_000, 4: 53_000 }),
+      mappings: [],
+      nowMs: 200_000,
+    })
+    expect(result.newMappings).toEqual([])
+    expect(result.events).toHaveLength(2)
+  })
+
+  it('resolves an ambiguous pair by elimination when one side gets mapped', () => {
+    // Slot 1 already mapped to row 3 — slot 2's only remaining candidate is row 4
+    const result = correlateSlotRows({
+      events: [event(1, 50_000), event(2, 51_000)],
+      rows: changedRows({ 3: 52_000, 4: 53_000 }),
+      mappings: [{ gsiSlot: 1, scanRow: 3 }],
+      nowMs: 200_000,
+    })
+    expect(result.newMappings).toEqual([{ gsiSlot: 2, scanRow: 4 }])
+  })
+
+  it('excludes unverified rows (hero already drafted at baseline time)', () => {
+    const rows = changedRows({ 4: 53_000 }).map((r) =>
+      r.row === 4 ? { ...r, baselineVerified: false } : r,
+    )
+    const result = correlateSlotRows({
+      events: [event(2, 50_000)],
+      rows,
+      mappings: [],
+      nowMs: 50_000 + AFTER + 1,
+    })
+    expect(result.newMappings).toEqual([])
+  })
+
+  it('blocks a commit when another event also claims the row', () => {
+    // Both events in window of row 4; only one row changed -> mutual claim, no commit
+    const result = correlateSlotRows({
+      events: [event(1, 50_000), event(2, 52_000)],
+      rows: changedRows({ 4: 53_000 }),
+      mappings: [],
+      nowMs: 80_000,
+    })
+    expect(result.newMappings).toEqual([])
+  })
+
+  it('resolves out-of-window pairs by per-team elimination', () => {
+    // Row confirmed way outside the event window (tooltip storm), but they are
+    // the last unmapped event+row of the team and both arrival windows passed
+    const eventAt = 50_000
+    const rowAt = eventAt + AFTER + 15_000
+    const result = correlateSlotRows({
+      events: [event(2, eventAt)],
+      rows: changedRows({ 4: rowAt }),
+      mappings: [],
+      nowMs: rowAt + BEFORE + 1,
+    })
+    expect(result.newMappings).toEqual([{ gsiSlot: 2, scanRow: 4 }])
+  })
+
+  it('holds per-team elimination until the row could still have an in-flight event', () => {
+    const eventAt = 50_000
+    const rowAt = eventAt + AFTER + 15_000
+    const result = correlateSlotRows({
+      events: [event(2, eventAt)],
+      rows: changedRows({ 4: rowAt }),
+      mappings: [],
+      nowMs: rowAt + BEFORE - 1,
+    })
+    expect(result.newMappings).toEqual([])
+    // The eligible row keeps the event alive past the prune grace so the
+    // elimination can still happen on a later call
+    expect(result.events).toHaveLength(1)
+  })
+
+  it('uses the latest event per slot (replay rewind re-pick)', () => {
+    const result = correlateSlotRows({
+      events: [event(2, 10_000, 'lion'), event(2, 90_000, 'sand_king')],
+      rows: changedRows({ 4: 92_000 }),
+      mappings: [],
+      nowMs: 90_000 + AFTER + 1,
+    })
+    expect(result.newMappings).toEqual([{ gsiSlot: 2, scanRow: 4 }])
+  })
+
+  it('prunes unmatchable events after the grace period', () => {
+    const result = correlateSlotRows({
+      events: [event(2, 10_000)],
+      rows: verifiedRows(),
+      mappings: [],
+      nowMs: 10_000 + 2 * AFTER + 1,
+    })
+    expect(result.prunedSlots).toEqual([2])
+    expect(result.events).toEqual([])
+  })
+
+  it('keeps unmatched events through the grace period', () => {
+    const result = correlateSlotRows({
+      events: [event(2, 10_000)],
+      rows: verifiedRows(),
+      mappings: [],
+      nowMs: 10_000 + 2 * AFTER - 1,
+    })
+    expect(result.prunedSlots).toEqual([])
+    expect(result.events).toHaveLength(1)
+  })
+
+  it('ignores events for already-mapped slots and preserves mappings', () => {
+    const result = correlateSlotRows({
+      events: [event(2, 90_000)],
+      rows: changedRows({ 4: 92_000 }),
+      mappings: [{ gsiSlot: 2, scanRow: 0 }],
+      nowMs: 200_000,
+    })
+    expect(result.mappings).toEqual([{ gsiSlot: 2, scanRow: 0 }])
+    expect(result.newMappings).toEqual([])
+    expect(result.events).toEqual([])
+  })
+
+  it('cascades: a rule-1 commit unlocks a per-team elimination', () => {
+    // Slot 1 cleanly matches row 3; slot 2 + row 4 are then the last pair
+    const result = correlateSlotRows({
+      events: [event(1, 50_000), event(2, 100_000)],
+      rows: changedRows({ 3: 52_000, 4: 160_000 }),
+      mappings: [],
+      nowMs: 200_000,
+    })
+    expect(result.mappings).toEqual([
+      { gsiSlot: 1, scanRow: 3 },
+      { gsiSlot: 2, scanRow: 4 },
+    ])
+  })
+})

--- a/tests/unit/core/domain/stream-board.test.ts
+++ b/tests/unit/core/domain/stream-board.test.ts
@@ -161,6 +161,7 @@ describe('buildStreamBoardState', () => {
           connected: true,
           gamePhase: 'DOTA_GAMERULES_STATE_HERO_SELECTION',
           clockTime: 0,
+          spectating: false,
           playerNames: [],
           playerModels: Object.assign(Array.from({ length: 10 }, () => null), {
             1: { npcName: 'sand_king', displayName: 'Sand King' },
@@ -247,6 +248,7 @@ describe('buildStreamBoardState', () => {
           connected: true,
           gamePhase: 'DOTA_GAMERULES_STATE_HERO_SELECTION',
           clockTime: 42,
+          spectating: false,
           playerNames: ['Alice', null, null, null, null, null, null, 'Bob', null, null],
           playerModels: [
             { npcName: 'sand_king', displayName: 'Sand King' },
@@ -271,6 +273,57 @@ describe('buildStreamBoardState', () => {
     expect(state.players[7].picks.map((p) => p.name)).toEqual(['hero1_slot1'])
     expect(state.players[1].picks).toEqual([])
     expect(state.players[1].draftScore).toBeNull()
+  })
+
+  it('places spectate GSI names/models only through slot-row mappings', () => {
+    const state = buildStreamBoardState(
+      makeInput({
+        gsi: {
+          connected: true,
+          gamePhase: 'DOTA_GAMERULES_STATE_HERO_SELECTION',
+          clockTime: 42,
+          spectating: true,
+          playerNames: ['Alice', 'Carol', null, null, null, null, null, 'Bob', null, null],
+          playerModels: Object.assign(Array.from({ length: 10 }, () => null), {
+            0: { npcName: 'sand_king', displayName: 'Sand King' },
+          }),
+        },
+        // GSI slot 0 ("Alice") sits on board row 2; slot 7 ("Bob") on row 9
+        slotRowMappings: [
+          { gsiSlot: 0, scanRow: 2 },
+          { gsiSlot: 7, scanRow: 9 },
+        ],
+      }),
+    )
+
+    expect(state.players[2].playerName).toBe('Alice')
+    expect(state.players[2].model?.npcName).toBe('sand_king')
+    expect(state.players[9].playerName).toBe('Bob')
+    // Slot 1 ("Carol") has no mapping — identity placement would be a guess,
+    // so her name appears nowhere
+    expect(state.players.filter((p) => p.playerName === 'Carol')).toEqual([])
+    // Unmapped rows show nothing rather than a wrong name
+    expect(state.players[0].playerName).toBeNull()
+    expect(state.players[0].model).toBeNull()
+    expect(state.players[7].playerName).toBeNull()
+  })
+
+  it('keeps identity placement while playing even when mappings exist', () => {
+    const state = buildStreamBoardState(
+      makeInput({
+        gsi: {
+          connected: true,
+          gamePhase: 'DOTA_GAMERULES_STATE_HERO_SELECTION',
+          clockTime: 42,
+          spectating: false,
+          playerNames: ['Alice', null, null, null, null, null, null, null, null, null],
+          playerModels: [],
+        },
+        slotRowMappings: [{ gsiSlot: 0, scanRow: 2 }],
+      }),
+    )
+    expect(state.players[0].playerName).toBe('Alice')
+    expect(state.players[2].playerName).toBeNull()
   })
 
   it('computes draft scores through the provided synergy lookup', () => {


### PR DESCRIPTION
## Problem

In spectate/replay sessions the streamer board places GSI player names by `team_slot`, but the draft screen's visual row order does not follow it — names land on wrong rows. Verified empirically that the mapping is **not derivable from any GSI field** (not `team_slot`, not raw `playerN` key order, not `player_slot`; the `abilities`/`draft` GSI sections are empty during hero selection, watched live).

## Mechanism

Correlate GSI hero-model updates with player-card pixel changes:

1. **Card capture** — the ml-worker now crops the 10 `heroes_coords` player cards (at `heroes_params` size, normalized to 48px) on every scan, mirroring the model-tile machinery. A "NO HERO" card is pixel-static; once that row's player drafts a model it permanently switches to animated hero art, so change detection vs the initial-scan baseline is recognition-free and offset-tolerant (the 48px downscale absorbs the spectator layout's coordinate nudges).
2. **Correlation** (`src/core/domain/slot-row-correlation.ts`, pure + fixture-tested) — when GSI reports slot S gained hero H in the same time window (−10s/+20s) that card row R first read changed, record S↔R. Mappings accumulate per draft (sticky); ambiguous multi-pick windows resolve by elimination, including a per-team endgame rule for pairs whose timing windows missed. Candidates are restricted to the event's team half (GSI teams are authoritative; only within-team order is scrambled).
3. **Placement** — `buildPlayerRows` places spectate GSI names/models **only** through a learned mapping; an unmapped row shows nothing rather than a probably-wrong name. Playing mode keeps the validated `team_slot` identity placement untouched.

## Safeguards

- **Two-scan persistence** before a card counts as changed (hover-tooltip guard, same rule as model tiles).
- **`baselineVerified`**: a row's changes only count once it has read *equal* to its baseline at least once — a card that already showed a hero at initial-scan time has an animated baseline that never compares clean and would read "changed" forever.
- **Commit gating**: an event maps only when its match window has **closed** (no future row can join) and the row is claimed by no other event; the per-team elimination additionally waits out both sides' arrival windows.
- **Replay rewinds**: cards revert to baseline (change state clears), GSI heroes revert to null, and both sides re-fire on the re-pick — repeat chances without ever contradicting a committed mapping. State clears on session reset and on a new `matchid`.
- Card detection runs on **every** capture regardless of the contamination guard's verdict (cards are spatially separate from the ability rows).

## Behavior change to be aware of

In spectate, player names no longer appear until each row's mapping is learned (~20–25s after that player's model pick reaches a scan), and rows whose pick predates the initial scan stay nameless. Wrong-row names seemed worse than briefly-absent ones.

## Validation

- 574 unit tests green (24 new: card change detection + correlation rules + spectate/playing board placement), typecheck + lint + electron-vite build clean.
- Real-replay validation still pending: watch `main.log` (`slot-mapping` scope) for `Player-card baselines captured` → `GSI hero events observed` → `Player cards changed` (diffs should sit well above threshold 10) → `GSI slot <-> scan row mapping committed`, and compare against board-vs-game screenshots. `Dropped unmatchable GSI hero events` is expected for pre-baseline picks. Seeking backwards past picks is a good stress test for the revert/re-fire path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
