### PR TITLE
fix(feedback): keep full-board scan as the failed-recognition snapshot

### DIFF
--- a/src/main/services/feedback-service.ts
+++ b/src/main/services/feedback-service.ts
@@ -9,9 +9,12 @@ import { generateHmacSignature, generateNonce } from './api-config'
 import type { DecodedScreenshot } from '@core/ml/preprocessing'
 
 // @DEV-GUIDE: Backs the "Report Failed Recognition" loop. The overlay button saves a
-// snapshot of the LAST SCAN (the exact screenshot the model classified, plus its raw
-// predictions) — not a fresh capture, so the reported image always matches the
-// misrecognition the user saw. The scan pipeline hands over the RAW bitmap (it never
+// snapshot of the LAST FULL-BOARD SCAN (the exact screenshot the model classified, plus
+// its raw predictions) — not a fresh capture, so the reported image always matches the
+// misrecognition the user saw. Targeted auto-rescans (restricted to a few player rows,
+// results often empty) are NOT recorded: they would replace the full-board snapshot
+// with a near-useless one. Full scans recur at least once per round in auto mode, so
+// the kept context stays fresh. The scan pipeline hands over the RAW bitmap (it never
 // PNG-encodes); the PNG is produced HERE, lazily, only when the user actually files a
 // report. Samples live under userData/feedback-samples/, one folder per snapshot
 // (screenshot.png + metadata.json), pruned to MAX_STORED_SAMPLES.
@@ -31,6 +34,11 @@ export interface ScanContext {
   screenshot: DecodedScreenshot
   resolution: string
   isInitialScan: boolean
+  /**
+   * Rescan only: player rows the scan was restricted to (targeted
+   * auto-rescan). Undefined = full-board scan.
+   */
+  targetedRows?: number[]
   results: unknown
 }
 
@@ -83,6 +91,10 @@ export function createFeedbackService(apiConfig: ApiConfig | null): FeedbackServ
 
   return {
     recordScanContext(ctx) {
+      // Targeted auto-rescans cover only a few rows (their results are often
+      // empty) — recording one would clobber the full-board snapshot the user
+      // is actually reporting. Keep the last full scan instead.
+      if (ctx.targetedRows) return
       lastScan = { ...ctx, capturedAt: new Date().toISOString() }
     },
 

--- a/src/main/services/scan-trigger-service.ts
+++ b/src/main/services/scan-trigger-service.ts
@@ -167,11 +167,15 @@ export function createScanTriggerService(
 
         // Remember exactly what the model saw so "Report Failed Recognition"
         // snapshots the misclassified screenshot, not a fresh capture
-        // (raw bitmap; the feedback service PNG-encodes lazily on report)
+        // (raw bitmap; the feedback service PNG-encodes lazily on report).
+        // The feedback service ignores targeted rescans — only full-board
+        // scans are worth reporting, and a row-restricted result set would
+        // clobber the snapshot the user actually saw fail.
         feedbackService.recordScanContext({
           screenshot,
           resolution,
           isInitialScan,
+          targetedRows: isInitialScan ? undefined : options?.heroOrders,
           results: result.results,
         })
 

--- a/tests/unit/main/services/feedback-service.test.ts
+++ b/tests/unit/main/services/feedback-service.test.ts
@@ -74,6 +74,31 @@ describe('feedback-service', () => {
       const service = createFeedbackService(null)
       await expect(service.saveSnapshot()).rejects.toThrow('No scan context')
     })
+
+    it('ignores targeted rescans so they never become the snapshot', () => {
+      const service = createFeedbackService(null)
+      service.recordScanContext(makeContext({ targetedRows: [3], results: [] }))
+      expect(service.hasScanContext()).toBe(false)
+    })
+
+    it('keeps the last full scan when a targeted rescan follows it', async () => {
+      const service = createFeedbackService(null)
+      service.recordScanContext(makeContext())
+      service.recordScanContext(
+        makeContext({ isInitialScan: false, targetedRows: [1, 7], results: [] }),
+      )
+      // Model-tile-only rescan (empty row list) is also targeted
+      service.recordScanContext(
+        makeContext({ isInitialScan: false, targetedRows: [], results: [] }),
+      )
+
+      await service.saveSnapshot()
+      const root = join(userDataDir, 'feedback-samples')
+      const [folder] = readdirSync(root)
+      const metadata = JSON.parse(readFileSync(join(root, folder, 'metadata.json'), 'utf-8'))
+      expect(metadata.isInitialScan).toBe(true)
+      expect(metadata.results.ultimates[0].name).toBe('test_ability')
+    })
   })
 
   describe('saveSnapshot', () => {


### PR DESCRIPTION
## What changed

Since the auto-rescan feature (#115), `scan-trigger-service` called `feedbackService.recordScanContext()` on **every** scan, including turn-driven targeted rescans. Those rescans are restricted to a few player rows and often return zero results, so "Report Failed Recognition" snapshotted the last targeted rescan instead of the scan the user actually saw fail — producing samples like `sample-2026-08-13T12-44-19-104Z` with a 143-byte `metadata.json` containing `"results": []` (pre-#115 samples were ~19KB).

Fix:

- `ScanContext` gained an optional `targetedRows` field; `recordScanContext()` ignores any context where it is set — including `[]`, the model-tile-only rescan. The policy lives in the feedback service so it is unit-testable.
- `scan-trigger-service` passes `targetedRows: isInitialScan ? undefined : options?.heroOrders`.
- The snapshot is therefore always the last **full-board** scan: initial scan, manual rescan, or the auto-rescan round-end full reconciliation (which runs at least once per round, so the kept context stays fresh).
- `@DEV-GUIDE` in `feedback-service.ts` updated to document the policy.

## Why not record targeted results?

Even non-empty targeted results were deliberately excluded: a row-restricted result set paired with a full-board screenshot is misleading metadata, and any selected-ability misread a targeted scan could catch also appears in the round-end full rescan — so nothing reportable is lost, and a one-row scan can never clobber a full snapshot the user is about to report.

## Tests

Two new unit tests in `feedback-service.test.ts`: a targeted rescan never becomes the snapshot (`hasScanContext()` stays false), and a full scan survives subsequent targeted + model-tile-only rescans with its full results intact in the saved metadata. All 14 tests pass; `tsc --noEmit` and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
