### PR TITLE
feat(ml): template-match picked-ability slots against official icons

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,6 +40,12 @@ maintenance spec — the authoritative map of what IS, not a build plan.
   validates class count against the model's output width at init. There is NO hardcoded class count
 - Preprocessing feeds RAW 0–255 float32 — the graph's Rescaling layer normalizes internally.
   Do not add normalization
+- The classifier handles POOL slots only. PICKED-ability slots are identified by template
+  matching (`core/ml/template-matcher.ts`): NCC against the official CDN icons cached in
+  `userData/stream-icons/abilities` (pick boxes render icons flat; crops are border-inset).
+  Candidates are scoped to pool + picked names; the classifier is the pick-slot fallback
+  only when no icons are cached. Went 40/40 on a board where the classifier missed 3 picks
+  and confidently misread a 4th
 - Retraining: `training/train.py` (+ isolated `training/gate.py`) via the "Retrain ML model"
   workflow → opens a model PR. FP16 only; INT8 collapsed accuracy twice (documented) — do not
   reintroduce quantization without beating the gate across multiple training runs

--- a/src/core/ml/preprocessing.ts
+++ b/src/core/ml/preprocessing.ts
@@ -63,6 +63,23 @@ export async function cropTile(
 }
 
 /**
+ * Decodes an icon image FILE (PNG) and resizes to a square raw RGB vector —
+ * used to build pick-slot template-matching candidates from the cached
+ * official CDN icons. Alpha is stripped so vectors align with screenshot crops.
+ */
+export async function loadIconVector(
+  filePath: string,
+  size: number,
+): Promise<Uint8Array> {
+  const raw = await sharp(filePath)
+    .resize(size, size, { kernel: 'linear' })
+    .removeAlpha()
+    .raw()
+    .toBuffer()
+  return new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength)
+}
+
+/**
  * Converts a raw uint8 RGB buffer to Float32Array.
  * Values are kept as 0-255 floats -- the model's Rescaling layer maps them to [-1, 1]
  * internally (x/127.5 - 1).

--- a/src/core/ml/template-matcher.ts
+++ b/src/core/ml/template-matcher.ts
@@ -1,0 +1,113 @@
+import {
+  PICK_TEMPLATE_EMPTY_STD,
+  PICK_TEMPLATE_MIN_MARGIN,
+  PICK_TEMPLATE_MIN_NCC,
+} from '@shared/constants/thresholds'
+
+// @DEV-GUIDE: Template matching for PICKED-ability slots. Pick boxes render the
+// icon flat and unscaled — pixel-identical to the official CDN art already cached
+// for the streamer view — so a picked slot is identified by nearest-neighbor
+// normalized cross-correlation (NCC) against those icons instead of the ML
+// classifier. NCC is invariant to the game's brightness/contrast shifts. The
+// classifier stays in charge of the POOL slots (skewed rendering) and serves as
+// the pick-slot fallback when no icon templates are available (ml-worker.ts).
+// Empty boxes are near-uniform dark pixels, detected by pixel std before
+// matching. Candidate scoping: a pick must come from the scanned draft pool, so
+// callers pass the pool's ability names to shrink 500+ icons to ~48 candidates
+// (bigger winner margins); scoping that would empty the template set falls back
+// to all templates, mirroring the classifier's class-mask fallback.
+// Pure TypeScript on raw RGB vectors — zero Electron/sharp imports; decoding
+// and cropping happen in the ML worker.
+
+/** A candidate icon, preprocessed to the compare size (raw RGB). */
+export interface IconTemplate {
+  name: string
+  vec: Uint8Array
+  mean: number
+  std: number
+}
+
+export interface PixelStats {
+  mean: number
+  std: number
+}
+
+export interface PickMatchResult {
+  /** Matched ability name, or null (empty slot / no acceptable match). */
+  name: string | null
+  /** Best NCC score in [-1, 1]; 0 for empty slots. */
+  score: number
+  /** True when the slot read as empty (uniform pixels) — matching was skipped. */
+  isEmpty: boolean
+}
+
+export function computePixelStats(vec: Uint8Array): PixelStats {
+  let sum = 0
+  for (let i = 0; i < vec.length; i++) sum += vec[i]
+  const mean = sum / vec.length
+  let varSum = 0
+  for (let i = 0; i < vec.length; i++) varSum += (vec[i] - mean) ** 2
+  return { mean, std: Math.sqrt(varSum / vec.length) }
+}
+
+/** Builds a template from a decoded icon vector (raw RGB at the compare size). */
+export function makeIconTemplate(name: string, vec: Uint8Array): IconTemplate {
+  const { mean, std } = computePixelStats(vec)
+  return { name, vec, mean, std }
+}
+
+function ncc(
+  a: Uint8Array,
+  aStats: PixelStats,
+  b: Uint8Array,
+  bStats: PixelStats,
+): number {
+  let dot = 0
+  for (let i = 0; i < a.length; i++) {
+    dot += (a[i] - aStats.mean) * (b[i] - bStats.mean)
+  }
+  return dot / (a.length * aStats.std * bStats.std)
+}
+
+/**
+ * Identifies one pick-slot crop (raw RGB at the compare size, border already
+ * inset away) against the icon templates.
+ */
+export function matchPickSlot(
+  vec: Uint8Array,
+  templates: readonly IconTemplate[],
+  candidateNames?: ReadonlySet<string>,
+): PickMatchResult {
+  const stats = computePixelStats(vec)
+  if (stats.std < PICK_TEMPLATE_EMPTY_STD) {
+    return { name: null, score: 0, isEmpty: true }
+  }
+
+  let scoped = templates
+  if (candidateNames && candidateNames.size > 0) {
+    const filtered = templates.filter((t) => candidateNames.has(t.name))
+    if (filtered.length > 0) scoped = filtered
+  }
+
+  let best = -Infinity
+  let bestName: string | null = null
+  let second = -Infinity
+  for (const t of scoped) {
+    if (t.std === 0 || t.vec.length !== vec.length) continue
+    const score = ncc(vec, stats, t.vec, t)
+    if (score > best) {
+      second = best
+      best = score
+      bestName = t.name
+    } else if (score > second) {
+      second = score
+    }
+  }
+
+  if (bestName === null) return { name: null, score: 0, isEmpty: false }
+
+  // A single-template scope has no runner-up; -Infinity second passes margin
+  const accepted =
+    best >= PICK_TEMPLATE_MIN_NCC && best - second >= PICK_TEMPLATE_MIN_MARGIN
+  return { name: accepted ? bestName : null, score: best, isEmpty: false }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -249,6 +249,8 @@ app.whenReady().then(async () => {
     windowTracker,
     feedbackService,
     dbService,
+    draftStore,
+    iconCache,
   )
 
   // EXPERIMENTAL: GSI-driven auto-rescan + pick attribution (setting-gated, default off)

--- a/src/main/services/ml-service.ts
+++ b/src/main/services/ml-service.ts
@@ -45,6 +45,9 @@ export interface MlService {
    * never be predicted. Omitted/empty → no masking.
    * @param heroOrders Rescan only: restrict the selected-abilities scan to
    * these player rows (targeted auto-rescan). Omitted → all rows.
+   * @param pickCandidateNames Rescan only: names the draft can actually
+   * contain (pool + picked), scoping pick-slot template matching. Omitted →
+   * match against every cached icon.
    */
   scan(
     screenshot: DecodedScreenshot,
@@ -52,6 +55,7 @@ export interface MlService {
     isInitialScan: boolean,
     activeClassNames?: string[],
     heroOrders?: number[],
+    pickCandidateNames?: string[],
   ): Promise<MlWorkerSuccessResponse>
   terminate(): Promise<void>
   isReady(): boolean
@@ -84,6 +88,12 @@ export function createMlService(): MlService {
       ? process.resourcesPath
       : join(app.getAppPath(), 'resources')
     return join(basePath, 'model', 'class_names.json')
+  }
+
+  // Official-icon cache written by icon-cache-service; the worker template-
+  // matches pick slots against it (falls back to the classifier when absent)
+  function getPickIconsDir(): string {
+    return join(app.getPath('userData'), 'stream-icons', 'abilities')
   }
 
   // @DEV-GUIDE: Single message router for all worker responses. Uses status field to distinguish
@@ -164,6 +174,7 @@ export function createMlService(): MlService {
           modelPath: getModelPath(),
           classNamesPath: getClassNamesPath(),
           useDirectML: false,
+          pickIconsDir: getPickIconsDir(),
         },
       }
       worker.postMessage(initMessage)
@@ -185,6 +196,7 @@ export function createMlService(): MlService {
     isInitialScan: boolean,
     activeClassNames?: string[],
     heroOrders?: number[],
+    pickCandidateNames?: string[],
   ): Promise<MlWorkerSuccessResponse> {
     if (!worker || !ready) {
       throw new Error('ML Worker not ready')
@@ -228,6 +240,7 @@ export function createMlService(): MlService {
           isInitialScan,
           activeClassNames,
           heroOrders,
+          pickCandidateNames,
         },
       }
 

--- a/src/main/services/scan-trigger-service.ts
+++ b/src/main/services/scan-trigger-service.ts
@@ -12,7 +12,10 @@ import type { WindowManager } from './window-manager'
 import type { ScanProcessingService } from './scan-processing-service'
 import type { WindowTrackerService } from './window-tracker-service'
 import type { FeedbackService } from './feedback-service'
+import type { IconCacheService } from './icon-cache-service'
 import type { AppStore } from '../store/app-store'
+import type { StoreApi } from 'zustand/vanilla'
+import type { DraftStore } from '../store/draft-store'
 import type { ScanResult } from '@shared/types'
 import type { InitialScanResults } from '@shared/types/ml'
 
@@ -26,6 +29,10 @@ import type { InitialScanResults } from '@shared/types/ml'
 // guard (rejected scans leave state untouched) — the pipeline itself never touches
 // the user's mouse. performScan resolves after enrichment is fully dispatched, so
 // callers can read the updated DraftStore pool immediately after awaiting it.
+// Pick-slot template matching support: rescans pass the draft's candidate names
+// (pool + picked, from DraftStore) to scope icon matching, and each initial scan
+// prefetches the pool's official icons so the worker's template set is warm
+// before the first pick — independent of the streamer view.
 
 const logger = log.scope('scan-trigger')
 
@@ -51,7 +58,28 @@ export function createScanTriggerService(
   windowTracker: WindowTrackerService,
   feedbackService: FeedbackService,
   dbService: DatabaseService,
+  draftStore: StoreApi<DraftStore>,
+  iconCache: IconCacheService,
 ): ScanTriggerService {
+  // Pick-slot template-matching candidates: the draft can only contain the
+  // initial pool plus names already picked (the pool cache removes picked
+  // names, so the union reconstructs the original 48). Empty before the first
+  // initial scan → the worker matches against every cached icon instead.
+  function getPickCandidateNames(): string[] {
+    const state = draftStore.getState()
+    const names = new Set<string>()
+    for (const slot of state.initialPoolAbilitiesCache.ultimates) {
+      if (slot.name) names.add(slot.name)
+    }
+    for (const slot of state.initialPoolAbilitiesCache.standard) {
+      if (slot.name) names.add(slot.name)
+    }
+    for (const slot of state.selectedAbilitiesCache) {
+      if (slot.name) names.add(slot.name)
+    }
+    return [...names]
+  }
+
   return {
     async performScan(isInitialScan, options): Promise<void> {
       try {
@@ -161,6 +189,7 @@ export function createScanTriggerService(
           isInitialScan,
           dbService.abilities.getAllNames(),
           isInitialScan ? undefined : options?.heroOrders,
+          isInitialScan ? undefined : getPickCandidateNames(),
         )
 
         appStore.setState({ mlStatus: 'ready' })
@@ -197,6 +226,21 @@ export function createScanTriggerService(
             tile: new Uint8Array(t.tile),
           })),
         )
+
+        // Warm the icon cache for the recognized pool so pick-slot template
+        // matching has its candidates before the first pick lands — even with
+        // the streamer view (the cache's other consumer) turned off.
+        // Fire-and-forget: rescans fall back to the classifier until icons land.
+        if (isInitialScan) {
+          const poolNames = getPickCandidateNames()
+          if (poolNames.length > 0) {
+            void iconCache.prefetchAbilities(poolNames).catch((error) => {
+              logger.warn('Pool icon prefetch failed', {
+                error: error instanceof Error ? error.message : String(error),
+              })
+            })
+          }
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         logger.error('Scan failed', { error: message })

--- a/src/main/workers/ml-worker.ts
+++ b/src/main/workers/ml-worker.ts
@@ -1,4 +1,6 @@
 import { parentPort } from 'worker_threads'
+import { readdir } from 'fs/promises'
+import { join } from 'path'
 import type {
   MlWorkerRequest,
   MlWorkerReadyResponse,
@@ -8,12 +10,16 @@ import type {
 } from '@shared/types/ml'
 import type { ScanResult, SlotCoordinate, ResolutionLayout } from '@shared/types'
 import { createOnnxClassifier } from '@core/ml/onnx-classifier'
-import { preprocessBatch, cropTile } from '@core/ml/preprocessing'
+import { preprocessBatch, cropTile, loadIconVector } from '@core/ml/preprocessing'
 import type { DecodedScreenshot } from '@core/ml/preprocessing'
 import type { ClassifierResult } from '@core/ml/classifier'
+import { makeIconTemplate, matchPickSlot } from '@core/ml/template-matcher'
+import type { IconTemplate } from '@core/ml/template-matcher'
 import {
   MODEL_TILE_COMPARE_SIZE,
   PLAYER_CARD_COMPARE_SIZE,
+  PICK_TEMPLATE_COMPARE_SIZE,
+  PICK_TEMPLATE_CROP_INSET_RATIO,
 } from '@shared/constants/thresholds'
 
 // @DEV-GUIDE: ML Worker thread entry point. Runs as a Node.js worker_thread, spawned by MlService.
@@ -35,7 +41,13 @@ import {
 // from an encoded buffer re-decoded the full screenshot per slot (~1.1s/scan at 1440p).
 //
 // For initial scan: processes ultimate + standard slots, extracts heroDefiningAbilities (ability_order===2).
-// For rescan: processes only the selected-ability slots.
+// For rescan: processes only the selected-ability slots. Those PICK slots are identified by
+// TEMPLATE MATCHING (core/ml/template-matcher.ts) against the official CDN icons in
+// payload.pickIconsDir (userData/stream-icons/abilities): pick boxes render icons flat, so a
+// border-inset crop NCC-matched against the cache beats the classifier, which regressed on
+// exactly these crops (missed picks + one confident misread on a real board). Templates load
+// lazily on the first rescan and pick up newly cached icons via a per-scan readdir diff.
+// The classifier remains the pick-slot path only when no templates are available.
 // Every scan additionally captures the 12 model portrait tiles (models_coords) as
 // normalized raw crops — the scan-processor diffs them against the initial-scan
 // baseline to detect picked models (see core/domain/model-pick-detection.ts) —
@@ -47,6 +59,41 @@ if (!parentPort) {
 }
 
 const classifier = createOnnxClassifier()
+
+// Pick-slot icon templates, keyed by ability name. Loaded lazily from
+// pickIconsDir on the first selected-abilities scan; each later scan diffs the
+// directory listing and loads only new files (the icon cache is append-only).
+let pickIconsDir: string | null = null
+const pickTemplates = new Map<string, IconTemplate>()
+let pickTemplatesDirBroken = false
+
+async function refreshPickTemplates(): Promise<IconTemplate[]> {
+  if (pickIconsDir === null || pickTemplatesDirBroken) return []
+  let files: string[]
+  try {
+    files = await readdir(pickIconsDir)
+  } catch {
+    // Missing/unreadable icon cache — classifier fallback for this session
+    pickTemplatesDirBroken = true
+    return []
+  }
+  for (const file of files) {
+    if (!file.endsWith('.png')) continue
+    const name = file.slice(0, -4)
+    if (pickTemplates.has(name)) continue
+    try {
+      const vec = await loadIconVector(
+        join(pickIconsDir, file),
+        PICK_TEMPLATE_COMPARE_SIZE,
+      )
+      pickTemplates.set(name, makeIconTemplate(name, vec))
+    } catch {
+      // Undecodable file — skip; the name stays eligible for a later retry
+      // only if the cache rewrites it, which it never does. Acceptable.
+    }
+  }
+  return [...pickTemplates.values()]
+}
 
 parentPort.on('message', async (message: MlWorkerRequest) => {
   try {
@@ -75,8 +122,10 @@ async function handleInit(payload: {
   modelPath: string
   classNamesPath: string
   useDirectML: boolean
+  pickIconsDir?: string
 }): Promise<void> {
   try {
+    pickIconsDir = payload.pickIconsDir ?? null
     await classifier.initialize(payload)
     const response: MlWorkerReadyResponse = {
       status: 'ready',
@@ -103,6 +152,7 @@ async function handleScan(payload: {
   isInitialScan: boolean
   activeClassNames?: string[]
   heroOrders?: number[]
+  pickCandidateNames?: string[]
 }): Promise<void> {
   if (!classifier.isReady()) {
     throw new Error('ML Worker not initialized')
@@ -117,6 +167,7 @@ async function handleScan(payload: {
     isInitialScan,
     activeClassNames,
     heroOrders,
+    pickCandidateNames,
   } = payload
   // The buffer arrives as a transferred RAW RGB bitmap — no decode step;
   // every slot crop reads from it directly.
@@ -149,6 +200,9 @@ async function handleScan(payload: {
       confidenceThreshold,
       activeSet,
       heroOrders ? new Set(heroOrders) : undefined,
+      pickCandidateNames && pickCandidateNames.length > 0
+        ? new Set(pickCandidateNames)
+        : undefined,
     )
   }
 
@@ -270,6 +324,7 @@ async function performSelectedAbilitiesScan(
   confidenceThreshold: number,
   activeClassNames?: ReadonlySet<string>,
   heroOrders?: ReadonlySet<number>,
+  pickCandidateNames?: ReadonlySet<string>,
 ): Promise<ScanResult[]> {
   const selectedCoords = coords.selected_abilities_coords
   if (!selectedCoords || selectedCoords.length === 0) return []
@@ -286,12 +341,65 @@ async function performSelectedAbilitiesScan(
     height: params?.height ?? c.height,
   }))
 
-  return identifySlots(
-    slotsToScan,
-    screenshot,
-    confidenceThreshold,
-    activeClassNames,
-  )
+  const templates = await refreshPickTemplates()
+  if (templates.length === 0) {
+    // No icon cache — classifier fallback (pre-template-matching behavior)
+    return identifySlots(
+      slotsToScan,
+      screenshot,
+      confidenceThreshold,
+      activeClassNames,
+    )
+  }
+
+  return matchPickSlots(slotsToScan, screenshot, templates, pickCandidateNames)
+}
+
+/** Template-matches pick-box slots against the official-icon templates. */
+async function matchPickSlots(
+  slots: SlotCoordinate[],
+  screenshot: DecodedScreenshot,
+  templates: IconTemplate[],
+  candidateNames?: ReadonlySet<string>,
+): Promise<ScanResult[]> {
+  const results: ScanResult[] = []
+  for (const slot of slots) {
+    let result = makeDefaultResult(slot)
+    if (slot.width > 0 && slot.height > 0) {
+      // Shave the pick box's border ring + rounded corners — off-distribution
+      // pixels for icons and classifier alike (see PICK_TEMPLATE_CROP_INSET_RATIO)
+      const inset = Math.round(slot.width * PICK_TEMPLATE_CROP_INSET_RATIO)
+      const insetSlot = {
+        ...slot,
+        x: slot.x + inset,
+        y: slot.y + inset,
+        width: slot.width - inset * 2,
+        height: slot.height - inset * 2,
+      }
+      try {
+        const crop = await cropTile(
+          screenshot,
+          insetSlot,
+          PICK_TEMPLATE_COMPARE_SIZE,
+        )
+        const match = matchPickSlot(
+          new Uint8Array(crop.buffer, crop.byteOffset, crop.byteLength),
+          templates,
+          candidateNames,
+        )
+        result = {
+          ...result,
+          name: match.name,
+          // NCC in [-1,1]; clamp so downstream confidence semantics (>= 0) hold
+          confidence: Math.max(0, match.score),
+        }
+      } catch {
+        // Out-of-bounds crop (layout drift) — keep the default null result
+      }
+    }
+    results.push(result)
+  }
+  return results
 }
 
 // @DEV-GUIDE: Core ML pipeline for a batch of slots. preprocessBatch crops each slot from the

--- a/src/shared/constants/thresholds.ts
+++ b/src/shared/constants/thresholds.ts
@@ -8,6 +8,28 @@ export const ML_CONFIDENCE_THRESHOLD = 0.9
 export const ML_CLASS_THRESHOLD_OVERRIDES: Readonly<Record<string, number>> = {
   crystal_maiden_crystal_nova: 0.5,
 }
+// Picked-slot recognition via template matching against official CDN icons
+// (core/ml/template-matcher.ts). Pick boxes render the icon FLAT (unlike the
+// skewed pool slots), so a normalized-cross-correlation match against the
+// stream-icons cache beats the classifier there: on a real 40-slot board the
+// classifier missed 3 picks and confidently misread a 4th; template matching
+// went 40/40 (2026-08-14, sample-2026-08-13T23-08-21-287Z).
+export const PICK_TEMPLATE_COMPARE_SIZE = 48
+// Pick boxes have a border ring + rounded corners the model/icons never saw;
+// insetting the crop by ~8% of the slot width (6px at 1440p's 73px) removes
+// them. Measured: shadowraze2 NCC 0.773 inset vs argmax LOST without inset.
+export const PICK_TEMPLATE_CROP_INSET_RATIO = 0.08
+// Acceptance: best NCC at or above MIN_NCC and ahead of the runner-up by
+// MIN_MARGIN, else the slot renders Unknown. Correct matches measured
+// 0.518-0.924 NCC with a +0.026 worst-case margin against all 539 icons;
+// margins widen when candidates are scoped to the scanned pool.
+export const PICK_TEMPLATE_MIN_NCC = 0.45
+export const PICK_TEMPLATE_MIN_MARGIN = 0.02
+// An empty pick box is near-uniform dark pixels: measured std 0.8 vs 54+ for
+// any real icon. Detected before matching — empties never reach the matcher
+// (the classifier used to argmax tusk_snowball 0.33-0.52 on them).
+export const PICK_TEMPLATE_EMPTY_STD = 5
+
 export const ML_MODEL_INIT_TIMEOUT = 30_000
 export const ML_PREDICTION_TIMEOUT = 10_000
 export const ML_WORKER_MAX_RESTART_ATTEMPTS = 3

--- a/src/shared/types/ml.ts
+++ b/src/shared/types/ml.ts
@@ -8,6 +8,13 @@ export interface MlWorkerInitRequest {
     modelPath: string
     classNamesPath: string
     useDirectML: boolean
+    /**
+     * Directory of official ability icons (userData/stream-icons/abilities,
+     * maintained by icon-cache-service). When present, picked-ability slots
+     * are identified by template matching against these icons instead of the
+     * classifier; absent/unreadable → classifier fallback for pick slots.
+     */
+    pickIconsDir?: string
   }
 }
 
@@ -34,6 +41,13 @@ export interface MlWorkerScanRequest {
      * Used by the GSI turn-driven auto-rescan to scan ~4 slots instead of 40.
      */
     heroOrders?: number[]
+    /**
+     * Rescan only: ability names the current draft can actually contain (the
+     * initial pool + already-picked names). Scopes pick-slot template matching
+     * to these icons so winner margins stay wide. Omitted/empty → match
+     * against every cached icon.
+     */
+    pickCandidateNames?: string[]
   }
 }
 

--- a/tests/unit/core/ml/template-matcher.test.ts
+++ b/tests/unit/core/ml/template-matcher.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computePixelStats,
+  makeIconTemplate,
+  matchPickSlot,
+} from '@core/ml/template-matcher'
+import type { IconTemplate } from '@core/ml/template-matcher'
+import {
+  PICK_TEMPLATE_COMPARE_SIZE,
+  PICK_TEMPLATE_EMPTY_STD,
+  PICK_TEMPLATE_MIN_NCC,
+} from '@shared/constants/thresholds'
+
+const VEC_LENGTH = PICK_TEMPLATE_COMPARE_SIZE * PICK_TEMPLATE_COMPARE_SIZE * 3
+
+/** Deterministic pseudo-random icon pattern — distinct per seed. */
+function makePattern(seed: number): Uint8Array {
+  const vec = new Uint8Array(VEC_LENGTH)
+  let state = seed * 2654435761 + 1
+  for (let i = 0; i < vec.length; i++) {
+    state = (state * 1103515245 + 12345) & 0x7fffffff
+    vec[i] = state % 256
+  }
+  return vec
+}
+
+/** Simulates the game's rendering: darken + slight uniform noise. */
+function gameRender(icon: Uint8Array, brightness = 0.8, noise = 10): Uint8Array {
+  const vec = new Uint8Array(icon.length)
+  let state = 42
+  for (let i = 0; i < icon.length; i++) {
+    state = (state * 1103515245 + 12345) & 0x7fffffff
+    const jitter = (state % (noise * 2 + 1)) - noise
+    vec[i] = Math.max(0, Math.min(255, Math.round(icon[i] * brightness + jitter)))
+  }
+  return vec
+}
+
+function makeTemplates(count: number): IconTemplate[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeIconTemplate(`ability_${i}`, makePattern(i)),
+  )
+}
+
+describe('computePixelStats', () => {
+  it('computes mean and std of a uniform vector', () => {
+    const stats = computePixelStats(new Uint8Array(VEC_LENGTH).fill(37))
+    expect(stats.mean).toBe(37)
+    expect(stats.std).toBe(0)
+  })
+
+  it('computes std of an alternating vector', () => {
+    const vec = new Uint8Array(VEC_LENGTH)
+    for (let i = 0; i < vec.length; i++) vec[i] = i % 2 === 0 ? 0 : 200
+    const stats = computePixelStats(vec)
+    expect(stats.mean).toBe(100)
+    expect(stats.std).toBe(100)
+  })
+})
+
+describe('matchPickSlot', () => {
+  it('matches a brightness-shifted noisy crop to the right icon', () => {
+    const templates = makeTemplates(20)
+    const crop = gameRender(makePattern(7))
+    const result = matchPickSlot(crop, templates)
+    expect(result.name).toBe('ability_7')
+    expect(result.isEmpty).toBe(false)
+    expect(result.score).toBeGreaterThan(PICK_TEMPLATE_MIN_NCC)
+  })
+
+  it('detects an empty (uniform dark) slot without matching', () => {
+    const crop = new Uint8Array(VEC_LENGTH).fill(8)
+    const result = matchPickSlot(crop, makeTemplates(5))
+    expect(result).toEqual({ name: null, score: 0, isEmpty: true })
+  })
+
+  it('treats near-uniform noise below the empty threshold as empty', () => {
+    const crop = new Uint8Array(VEC_LENGTH)
+    for (let i = 0; i < crop.length; i++) {
+      crop[i] = 10 + (i % 3 === 0 ? Math.floor(PICK_TEMPLATE_EMPTY_STD) - 4 : 0)
+    }
+    expect(computePixelStats(crop).std).toBeLessThan(PICK_TEMPLATE_EMPTY_STD)
+    const result = matchPickSlot(crop, makeTemplates(5))
+    expect(result.isEmpty).toBe(true)
+    expect(result.name).toBeNull()
+  })
+
+  it('scopes matching to candidate names', () => {
+    const templates = makeTemplates(20)
+    const crop = gameRender(makePattern(7))
+    const scoped = matchPickSlot(crop, templates, new Set(['ability_3', 'ability_7']))
+    expect(scoped.name).toBe('ability_7')
+    // Scoping away the true icon must not produce a confident false match
+    const wrongScope = matchPickSlot(crop, templates, new Set(['ability_3', 'ability_4']))
+    expect(wrongScope.name).toBeNull()
+  })
+
+  it('falls back to all templates when no candidate has a template', () => {
+    const templates = makeTemplates(20)
+    const crop = gameRender(makePattern(7))
+    const result = matchPickSlot(crop, templates, new Set(['not_cached_yet']))
+    expect(result.name).toBe('ability_7')
+  })
+
+  it('rejects when two near-identical templates tie (margin gate)', () => {
+    const pattern = makePattern(1)
+    const templates = [
+      makeIconTemplate('twin_a', pattern),
+      makeIconTemplate('twin_b', pattern),
+    ]
+    const result = matchPickSlot(gameRender(pattern), templates)
+    expect(result.name).toBeNull()
+    expect(result.isEmpty).toBe(false)
+    expect(result.score).toBeGreaterThan(PICK_TEMPLATE_MIN_NCC)
+  })
+
+  it('rejects a crop that resembles no template', () => {
+    // Smooth gradient — structurally unlike the pseudo-random templates
+    const crop = new Uint8Array(VEC_LENGTH)
+    for (let i = 0; i < crop.length; i++) crop[i] = Math.floor((i / crop.length) * 255)
+    const result = matchPickSlot(crop, makeTemplates(20))
+    expect(result.name).toBeNull()
+    expect(result.isEmpty).toBe(false)
+  })
+
+  it('accepts a single-template scope with no runner-up', () => {
+    const templates = makeTemplates(1)
+    const result = matchPickSlot(gameRender(makePattern(0)), templates)
+    expect(result.name).toBe('ability_0')
+  })
+
+  it('skips templates with mismatched vector length or zero variance', () => {
+    const templates: IconTemplate[] = [
+      makeIconTemplate('short', makePattern(2).slice(0, 100)),
+      makeIconTemplate('flat', new Uint8Array(VEC_LENGTH).fill(50)),
+      makeIconTemplate('real', makePattern(3)),
+    ]
+    const result = matchPickSlot(gameRender(makePattern(3)), templates)
+    expect(result.name).toBe('real')
+  })
+})

--- a/tests/unit/main/services/ml-service.test.ts
+++ b/tests/unit/main/services/ml-service.test.ts
@@ -6,6 +6,7 @@ vi.mock('electron', () => ({
   app: {
     isPackaged: false,
     getAppPath: () => '/mock/app/path',
+    getPath: () => '/mock/user-data',
   },
 }))
 
@@ -79,6 +80,7 @@ describe('MlService', () => {
           modelPath: expect.stringContaining('ability_classifier_fp16.onnx'),
           classNamesPath: expect.stringContaining('class_names.json'),
           useDirectML: false,
+          pickIconsDir: expect.stringContaining('stream-icons'),
         },
       })
 


### PR DESCRIPTION
## What

Picked-ability slots (the pick boxes in player rows) are no longer identified by the ML classifier. They are template-matched against the official CDN ability icons already cached for the streamer view (`userData/stream-icons/abilities`), using normalized cross-correlation. The classifier keeps handling pool slots and remains the pick-slot fallback only when no icons are cached yet.

## Why

Pick boxes render icons flat — pixel-identical to the official art — while the classifier regressed on exactly these crops. On a real 1440p board (feedback sample 2026-08-13):

| Slot | Classifier | Template match |
|---|---|---|
| `nevermore_shadowraze2` | `kunkka_x_marks_the_spot` 0.54 → Unknown | ✅ 0.773 |
| `medusa_gorgon_grasp` | `pangolier_swashbuckle` 0.74 → Unknown | ✅ 0.518 |
| `earthshaker_aftershock` | `tusk_snowball` 0.39 → Unknown | ✅ 0.922 |
| `puck_illusory_orb` | `lone_druid_savage_roar` **0.998 — displayed wrong** | ✅ 0.659 |
| 22 empty boxes | argmax `tusk_snowball` 0.33–0.52 (noise) | ✅ empty via pixel-std |

Template matching went **40/40** on that board, validated end-to-end by spawning the built worker on the original screenshot.

## How

- `src/core/ml/template-matcher.ts` — pure NCC matcher (brightness/contrast-invariant, so the game''s darkening doesn''t matter), empty-box detection by pixel std (measured 0.8 vs 54+), candidate scoping with an all-templates fallback mirroring the classifier''s class mask.
- `ml-worker` — pick crops are border-inset ~8% of slot width before matching (the box''s border ring + rounded corners are off-distribution pixels; the inset alone flips shadowraze2 from argmax-lost to 0.773). Templates lazy-load from `pickIconsDir` on the first rescan and pick up newly cached icons via a per-scan readdir diff.
- `scan-trigger` — rescans pass the draft''s candidate names (initial pool + already picked, from DraftStore) so ~48 icons compete instead of 539; each initial scan prefetches the pool''s icons so templates are warm before the first pick, independent of the streamer view being on.
- Thresholds documented with measurements in `src/shared/constants/thresholds.ts` (`PICK_TEMPLATE_*`).

## Reviewer notes

- Output shape is unchanged (`ScanResult[]`), so the merge logic, contamination guard, pick attribution, and stream board are untouched.
- `confidence` on pick slots now carries the NCC score (clamped to ≥ 0) instead of a softmax probability; it feeds the same Unknown rendering path.
- Acceptance thresholds (min NCC 0.45, margin 0.02) are calibrated on one 1440p board — the 8% inset ratio scales with slot size, but other resolutions haven''t been live-tested yet. If a pick reads Unknown on another layout, a failed-recognition report will pinpoint it.
- The `ML_CLASS_THRESHOLD_OVERRIDES` stopgap now only matters for pool slots.
- 11 new unit tests for the matcher; full suite 603 passing; typecheck/lint/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)