### PR TITLE
fix(gsi): correct live-game spot recognition via countdown + card-OCR row derivation

### DIFF
--- a/src/core/domain/own-row-detection.ts
+++ b/src/core/domain/own-row-detection.ts
@@ -1,0 +1,78 @@
+// @DEV-GUIDE: Own draft-row derivation for PLAYING sessions.
+// Problem: while playing, GSI reports the local player's team_name + team_slot
+// (and player_slot), but NEITHER matches the draft screen's visual row order —
+// verified empirically 2026-08-25 across live games (radiant game: visual row 3,
+// team_slot 2, player_slot 3; dire game: visual row 5, team_slot 3, player_slot 8).
+// Only the TEAM half (team_name) is trustworthy. This mirrors the spectate/replay
+// finding that motivated slot-row-correlation.ts.
+// Mechanism: the GSI hero block reports the local player's hero model from the
+// moment they DRAFT it, and the same moment their player card renders the hero's
+// name — which the OCR service reads into ocrHeroNamesByRow (names are always
+// English; candidates are pool-scoped). Models are unique per player, so matching
+// the GSI npc name against the OCR'd card names pins the local player's row.
+// The team half, when known, acts as a veto against OCR misreads.
+// (A green-highlight border detector was tried for pre-model-draft instant
+// detection and REMOVED 2026-08-26: live data showed every ally card carries a
+// green border, the own card is not reliably the brightest, and screen-state
+// artifacts could pass any margin gate — it committed a wrong row in testing.
+// Candidate replacement if instant detection is ever needed: the top pick-order
+// strip marks the local player's turns with bright green outlines from second 0.)
+
+/**
+ * Npc-short-name -> DB-name aliases where the difference survives underscore
+ * normalization. Full-DB audit 2026-08-26 (127 heroes): Zeus is the ONLY one.
+ */
+const NPC_DB_ALIASES: Readonly<Record<string, string>> = {
+  zuus: 'zeus',
+}
+
+/**
+ * Canonical comparison token for a hero name from ANY source — GSI npc short
+ * name ("drow_ranger", "zuus"), DB hero name ("drowranger", "monkey_king" —
+ * the DB is inconsistent about underscores), or model-reference name.
+ * Lowercase, underscores stripped, npc aliases applied.
+ */
+export function heroNameToken(name: string): string {
+  const normalized = name.toLowerCase().replace(/_/g, '')
+  return NPC_DB_ALIASES[normalized] ?? normalized
+}
+
+export interface OwnRowResolutionInput {
+  /** OCR results per player row 0-9 (DraftStore.ocrHeroNamesByRow). */
+  ocrHeroNamesByRow: Record<number, { name: string }>
+  /** GSI hero block npc short name, e.g. "drow_ranger". */
+  localHeroNpcName: string
+  /**
+   * First row of the local player's team half (0 = radiant, 5 = dire), from
+   * GSI team_name; null when unknown. Used only as a sanity veto.
+   */
+  teamHalfStart: 0 | 5 | null
+}
+
+/**
+ * Resolve the local player's visual draft row from the OCR'd card names.
+ * Returns null (caller retries on a later scan/snapshot) when the model has
+ * not been OCR'd yet, the match is ambiguous, or it contradicts the team half.
+ */
+export function resolveOwnRowFromOcr(input: OwnRowResolutionInput): number | null {
+  const token = heroNameToken(input.localHeroNpcName)
+
+  const matches: number[] = []
+  for (const [rowKey, ocr] of Object.entries(input.ocrHeroNamesByRow)) {
+    if (heroNameToken(ocr.name) === token) matches.push(Number(rowKey))
+  }
+  // Models are unique per player; two matching rows means an OCR misread —
+  // refuse rather than guess (the misread row never re-OCRs, but the pool
+  // scoping makes duplicates rare in the first place).
+  if (matches.length !== 1) return null
+
+  const row = matches[0]
+  if (row < 0 || row > 9) return null
+  if (
+    input.teamHalfStart !== null &&
+    (row < input.teamHalfStart || row >= input.teamHalfStart + 5)
+  ) {
+    return null
+  }
+  return row
+}

--- a/src/core/domain/scan-processor.ts
+++ b/src/core/domain/scan-processor.ts
@@ -511,6 +511,7 @@ export function processScanResults(
     heroModels: enrichedHeroModels,
     heroesForMySpotUI,
     selectedHeroForDraftingDbId: state.mySelectedSpotDbId,
+    selectedSpotHeroOrder: state.mySelectedSpotHeroOrder,
     selectedModelHeroOrder: state.mySelectedModelHeroOrder,
     heroesCoords,
     heroesParams,

--- a/src/core/domain/stream-board.ts
+++ b/src/core/domain/stream-board.ts
@@ -155,7 +155,9 @@ function buildPlayerRows(
 
   // Spectate: GSI arrays are slot-indexed and the within-team slot order does
   // NOT match the board's row order — only a correlated mapping may place a
-  // name/model on a row. Playing: the index IS the row (validated team_slot).
+  // name/model on a row. Playing: gsiInfo() already placed the local player at
+  // their OCR-derived row (own-row-detection.ts), so the arrays are row-indexed
+  // and the identity read below is correct.
   const slotByRow = new Map(slotRowMappings.map((m) => [m.scanRow, m.gsiSlot]))
   const gsiSlotForRow = (row: number): number | null =>
     gsi.spectating ? (slotByRow.get(row) ?? null) : row

--- a/src/core/gsi/draft-clock.ts
+++ b/src/core/gsi/draft-clock.ts
@@ -102,6 +102,40 @@ export function turnsEndedBetween(
 }
 
 /**
+ * Resolve the LOCAL player's row from the on-screen "YOU WILL DRAFT IN: N"
+ * countdown (playing mode only — spectators never see it). N seconds after the
+ * capture moment, the local player's next turn STARTS; matching that instant
+ * against the schedule's turn starts identifies the turn — and its playerIndex
+ * IS the visual row (user-validated timing model: radiant 1 picks at clock 0,
+ * dire 1 at +7s, radiant 2 at +14s, ...). Works from the preview onward
+ * (elapsedS is negative before clock zero) and across round breaks. Returns
+ * null when no turn start falls within the tolerance (OCR misread, or the
+ * anchor drifted) — turn starts are >= 7s apart, so the default 2.5s tolerance
+ * can never match two windows.
+ */
+export function countdownTargetRow(input: {
+  /** OCR'd countdown value in seconds. */
+  countdownS: number
+  /** Seconds since the pick-phase anchor at the CAPTURE moment (negative during preview). */
+  elapsedS: number
+  toleranceS?: number
+  schedule?: TurnWindow[]
+}): { row: number; deltaS: number } | null {
+  const tolerance = input.toleranceS ?? 2.5
+  const schedule = input.schedule ?? buildTurnSchedule()
+  const turnStartS = input.elapsedS + input.countdownS
+
+  let best: { row: number; deltaS: number } | null = null
+  for (const window of schedule) {
+    const deltaS = Math.abs(window.startS - turnStartS)
+    if (deltaS <= tolerance && (best === null || deltaS < best.deltaS)) {
+      best = { row: window.playerIndex, deltaS }
+    }
+  }
+  return best
+}
+
+/**
  * True when `elapsedS` falls in a between-rounds break (or past the final turn) —
  * the moments a full-pool reconciliation rescan is safe and cheap to run.
  */

--- a/src/core/gsi/parser.ts
+++ b/src/core/gsi/parser.ts
@@ -54,9 +54,13 @@ function resolveSlotIndex(
 }
 
 /**
- * Playing-mode local player block -> scan slot index 0-9, from the authoritative
- * team_name ("radiant"/"dire") + team_slot (0-4 within the team). Null when either
- * is absent (menus, spectating) — callers treat that as "slot unknown".
+ * Playing-mode local player block -> slot index 0-9 from team_name
+ * ("radiant"/"dire") + team_slot (0-4 within the team). Null when either is
+ * absent (menus, spectating) — callers treat that as "slot unknown".
+ * WARNING: this is LOBBY order. Only the team half (<5 / >=5) matches the
+ * draft screen; the within-team order does NOT (disproven on live games
+ * 2026-08-25, and player_slot doesn't match either). Never use it to place
+ * anything on a visual row — see core/domain/own-row-detection.ts.
  */
 function localSlotIndex(player: Record<string, unknown>): number | null {
   const teamName = asString(player['team_name'])

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -147,6 +147,7 @@ app.whenReady().then(async () => {
     () => draftStore.getState().draftTimeline,
     () => draftStore.getState().modelAssignments,
     () => draftStore.getState().slotRowMappings,
+    () => draftStore.getState().mySelectedSpotHeroOrder,
   )
   // Auto "My Spot" from GSI (playing mode) — re-applied after each initial scan
   const spotDetectionService = createSpotDetectionService(

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -181,6 +181,7 @@ export function registerIpcHandlers(
       heroModels: [],
       heroesForMySpotUI: [],
       selectedHeroForDraftingDbId: null,
+      selectedSpotHeroOrder: null,
       selectedModelHeroOrder: null,
       heroesCoords: coords.heroes_coords ?? [],
       heroesParams: coords.heroes_params ?? { width: 0, height: 0 },

--- a/src/main/services/auto-rescan-service.ts
+++ b/src/main/services/auto-rescan-service.ts
@@ -11,9 +11,11 @@ import { gsiSnapshotMode } from '@core/gsi/parser'
 import {
   buildTurnSchedule,
   turnsEndedBetween,
+  countdownTargetRow,
   type TurnWindow,
 } from '@core/gsi/draft-clock'
 import { attributePicksByRow } from '@core/domain/pick-attribution'
+import { heroNameToken } from '@core/domain/own-row-detection'
 import {
   AUTO_RESCAN_TICK_MS,
   AUTO_RESCAN_PICK_VISIBLE_DELAY_S,
@@ -105,9 +107,12 @@ export function createAutoRescanService(
    * exactly when the assigning player's turn ends (user-verified), so the turn
    * that triggered the first-seen scan identifies the picker. The mapping is
    * tentative until the two-scan persistence commit (commit time lags by one
-   * turn and must NOT be used for attribution).
+   * turn and must NOT be used for attribution). 'self' marks the user's own
+   * model (GSI hero block match): its row is resolved at COMMIT time from the
+   * OCR-derived My Spot (localPlayer.slotIndex is lobby-order, not the visual
+   * row — see own-row-detection.ts), which may still be resolving at first-seen.
    */
-  const tentativeModelPicker = new Map<number, number>()
+  const tentativeModelPicker = new Map<number, number | 'self'>()
   /** Accepted rescans this session — the 1st sweeps up all preview-time picks
    * at once, so its timing carries no per-turn information. */
   let acceptedRescans = 0
@@ -118,6 +123,14 @@ export function createAutoRescanService(
   let lastClockTime: number | null = null
   /** Sticky per draft session: a big clock rewind marked this as a replay. */
   let replayDetected = false
+  /** A clock <= -8 (the preview ramp) was seen — proves we witnessed the draft
+   * start, the precondition for a trustworthy pick-phase anchor. */
+  let sawPreviewClock = false
+  let scheduleUnknownLogged = false
+  /** Rows already given their one empty-targeted-scan retry this turn. */
+  const retriedEmptyRows = new Set<number>()
+  /** Capture stamp of the last countdown reading already logged. */
+  let lastCountdownAtMs = 0
 
   function resetDraftSession(): void {
     draftClockSeenAtMs = null
@@ -130,6 +143,10 @@ export function createAutoRescanService(
     lastReplayScanMs = 0
     lastClockTime = null
     replayDetected = false
+    sawPreviewClock = false
+    scheduleUnknownLogged = false
+    retriedEmptyRows.clear()
+    lastCountdownAtMs = 0
     tentativeModelPicker.clear()
     acceptedRescans = 0
     modelConfirmAtMs = null
@@ -187,6 +204,13 @@ export function createAutoRescanService(
       logger.info('Draft clock identified', { clockTime: snapshot.clockTime })
     }
 
+    // Per-turn countdowns only reach -7; anything deeper is the PREVIEW ramp.
+    // Seeing it proves we witnessed the draft from (near) the start — the only
+    // condition under which the anchor below is trustworthy. Joining mid-draft
+    // (app/GSI started late) must NOT anchor: clock-0 crossings happen at every
+    // turn boundary and would offset the whole schedule (observed 2026-08-26).
+    if (snapshot.clockTime <= -8) sawPreviewClock = true
+
     // Replay detector: a spectated draft whose clock jumps BACKWARD beyond the
     // per-turn countdown depth is being seeked — the turn schedule is void for
     // the rest of this session. (Playing-mode clocks legitimately rewind by
@@ -214,6 +238,7 @@ export function createAutoRescanService(
     // where the preview clock reads exactly 0. Once wall time passes the
     // anchor, negative clocks are turn timers and must never touch it.
     const now = Date.now()
+    if (!sawPreviewClock) return // mid-draft join: no trustworthy anchor exists
     if (snapshot.clockTime < 0) {
       if (pickAnchorMs === null || now < pickAnchorMs) {
         if (pickAnchorMs === null) {
@@ -253,6 +278,41 @@ export function createAutoRescanService(
       const { snapshot, connected } = streamService.getGsiState()
       if (!connected || snapshot?.gamePhase !== GSI_HERO_SELECTION_PHASE) return
 
+      // Countdown-derived own-row candidate: "YOU WILL DRAFT IN: N" at capture
+      // time t means the local player's next turn starts at t+N — matched
+      // against the schedule via the anchor. Published to DraftStore for
+      // spot-detection (validated 4/4 across slots on live lobby games,
+      // 2026-08-26, deltas 1.5-2.1s).
+      const countdown = draftStore.getState().draftCountdown
+      if (
+        countdown !== null &&
+        countdown.atMs !== lastCountdownAtMs &&
+        pickAnchorMs !== null &&
+        sawPreviewClock
+      ) {
+        lastCountdownAtMs = countdown.atMs
+        const elapsedAtCapture = (countdown.atMs - pickAnchorMs) / 1000
+        const candidate = countdownTargetRow({
+          countdownS: countdown.seconds,
+          elapsedS: elapsedAtCapture,
+        })
+        logger.info('Countdown spot candidate', {
+          n: countdown.seconds,
+          elapsedS: Math.round(elapsedAtCapture),
+          row: candidate?.row ?? null,
+          deltaS: candidate === null ? null : Number(candidate.deltaS.toFixed(1)),
+        })
+        if (candidate !== null) {
+          draftStore.setState({
+            countdownSpotRow: {
+              row: candidate.row,
+              deltaS: candidate.deltaS,
+              atMs: countdown.atMs,
+            },
+          })
+        }
+      }
+
       if (poolNames().length === 0) {
         // Fallback auto INITIAL scan: the user hasn't scanned the pool yet —
         // do it for them once, autoInitialScanDelayS (user setting; slower PCs
@@ -273,17 +333,22 @@ export function createAutoRescanService(
         return
       }
 
-      // REPLAY (auto-detected via clock rewind): the turn schedule is void —
-      // plain periodic FULL rescans; attribution stays row-diff-correct.
+      // REPLAY (auto-detected via clock rewind) or MID-DRAFT JOIN (preview ramp
+      // never seen, so no trustworthy anchor exists): the turn schedule is void
+      // — plain periodic FULL rescans; attribution stays row-diff/OCR-correct.
       // Live spectating (no rewind seen) runs the turn-driven path below.
-      if (replayDetected) {
+      if (replayDetected || !sawPreviewClock) {
+        if (!replayDetected && !scheduleUnknownLogged) {
+          scheduleUnknownLogged = true
+          logger.info('Joined draft mid-progress (no preview clock) — periodic full rescans')
+        }
         if (Date.now() - lastReplayScanMs < AUTO_RESCAN_REPLAY_INTERVAL_MS) {
           return
         }
         lastReplayScanMs = Date.now()
         pendingRows.clear()
         fullScanDue = false
-        await runRescan(undefined, undefined, snapshot.clockTime, null)
+        await runRescan(undefined, undefined, snapshot.clockTime, null, 'periodic')
         return
       }
 
@@ -292,7 +357,7 @@ export function createAutoRescanService(
       // commits in ~1.5s instead of one full turn later
       if (modelConfirmAtMs !== null && Date.now() >= modelConfirmAtMs) {
         modelConfirmAtMs = null
-        await runRescan([], undefined, snapshot.clockTime, null)
+        await runRescan([], undefined, snapshot.clockTime, null, 'model-confirm')
         return
       }
 
@@ -310,6 +375,8 @@ export function createAutoRescanService(
         const ended = turnsEndedBetween(schedule, queuedUpToS, visibleUpToS)
         for (const turn of ended) {
           pendingRows.add(turn.playerIndex)
+          // A NEW turn re-earns the row its one empty-scan retry
+          retriedEmptyRows.delete(turn.playerIndex)
           // Last turn of a round -> reconcile the whole board in the 5s break
           if (turn.seq % 10 === 9) fullScanDue = true
         }
@@ -332,12 +399,32 @@ export function createAutoRescanService(
   }
 
   /**
-   * Attribute model-tile changes to players. Newly PENDING tiles are mapped to
-   * the single turn that triggered this scan (ambiguous multi-turn scans and
-   * the first sweep-up rescan attribute nothing); newly COMMITTED tiles turn
-   * their tentative mapping into a stored assignment. The user's own model is
-   * attributed from GSI directly, which also overrides any tentative guess.
+   * Attribute model-tile changes to players. AUTHORITATIVE source: the card
+   * OCR (the drafter's card prints the hero's name — see ocrRowForPoolHero);
+   * turn timing is the fallback while OCR hasn't read the card. Newly PENDING
+   * tiles are tentatively mapped to the single turn that triggered this scan
+   * (ambiguous multi-turn scans and the first sweep-up rescan attribute
+   * nothing); newly COMMITTED tiles resolve OCR-first, then tentative. The
+   * user's own model resolves via the OCR-derived My Spot ('self').
    */
+  /**
+   * The unique player row whose card OCR'd as the given POOL hero, or null
+   * (not OCR'd yet / ambiguous). Direct evidence of who drafted the model —
+   * the draft screen prints the hero's name on the drafter's card.
+   */
+  function ocrRowForPoolHero(order: number): number | null {
+    const state = draftStore.getState()
+    const heroName = state.identifiedHeroModelsCache.find(
+      (m) => m.heroOrder === order,
+    )?.heroName
+    if (!heroName) return null
+    const token = heroNameToken(heroName)
+    const rows = Object.entries(state.ocrHeroNamesByRow)
+      .filter(([, ocr]) => heroNameToken(ocr.name) === token)
+      .map(([row]) => Number(row))
+    return rows.length === 1 ? rows[0] : null
+  }
+
   function attributeModelPicks(
     prevPending: readonly number[],
     prevPicked: readonly number[],
@@ -347,8 +434,7 @@ export function createAutoRescanService(
     const { snapshot } = streamService.getGsiState()
 
     const localNpc = snapshot?.localHeroNpcName ?? null
-    const localSlot = snapshot?.localPlayer?.slotIndex ?? null
-    const localDbName = localNpc ? localNpc.replace(/_/g, '') : null
+    const localToken = localNpc ? heroNameToken(localNpc) : null
 
     // Tentative mapping at FIRST-SEEN time
     const prevPendingSet = new Set(prevPending)
@@ -359,8 +445,12 @@ export function createAutoRescanService(
       const heroName = state.identifiedHeroModelsCache.find(
         (m) => m.heroOrder === order,
       )?.heroName
-      if (localDbName !== null && localSlot !== null && heroName === localDbName) {
-        tentativeModelPicker.set(order, localSlot)
+      if (
+        localToken !== null &&
+        heroName !== undefined &&
+        heroNameToken(heroName) === localToken
+      ) {
+        tentativeModelPicker.set(order, 'self')
       } else if (acceptedRescans > 1 && scannedRows?.length === 1) {
         tentativeModelPicker.set(order, scannedRows[0])
       }
@@ -374,15 +464,30 @@ export function createAutoRescanService(
       if (!stillRelevant.has(order)) tentativeModelPicker.delete(order)
     }
 
-    // Commit: persist the tentative mapping as an assignment
+    // Commit priority: the LOCAL player's model goes to the known My Spot row
+    // (countdown/OCR-validated — a single card misread must never move it,
+    // observed 2026-08-26); other models take the card-OCR row (direct
+    // evidence), with the turn-timing tentative mapping as the fallback while
+    // OCR hasn't read the card (reconcileModelAssignmentsWithOcr fixes later)
     const prevPickedSet = new Set(prevPicked)
     const assignments: import('../store/draft-store').ModelAssignment[] = []
     for (const order of state.pickedModelHeroOrders) {
       if (prevPickedSet.has(order)) continue
-      const playerIndex = tentativeModelPicker.get(order)
+      const tentative = tentativeModelPicker.get(order)
       tentativeModelPicker.delete(order)
+      const ocrRow = ocrRowForPoolHero(order)
+      const spotRow =
+        tentative === 'self' ? state.mySelectedSpotHeroOrder : null
+      if (spotRow !== null && ocrRow !== null && ocrRow !== spotRow) {
+        logger.warn(
+          'Card OCR disagrees with My Spot for the local model — trusting the spot',
+          { order, ocrRow, spotRow },
+        )
+      }
+      const playerIndex =
+        spotRow ?? ocrRow ?? (tentative === 'self' ? undefined : tentative)
       if (playerIndex === undefined) {
-        logger.info('Model pick left unattributed (ambiguous timing)', { order })
+        logger.info('Model pick left unattributed (awaiting card OCR)', { order })
         continue
       }
       assignments.push({ poolHeroOrder: order, playerIndex })
@@ -391,6 +496,61 @@ export function createAutoRescanService(
       draftStore.getState().appendModelAssignments(assignments)
       logger.info('Model picks attributed', { assignments })
     }
+  }
+
+  /**
+   * Card OCR lands on its own schedule (often a scan after the model commit)
+   * and outranks turn-timing guesses: append assignments timing couldn't make
+   * and CORRECT ones it got wrong (observed: adjacent-turn misattribution put
+   * Night Stalker on the wrong team's row, 2026-08-26).
+   */
+  function reconcileModelAssignmentsWithOcr(): boolean {
+    const state = draftStore.getState()
+    if (state.pickedModelHeroOrders.length === 0) return false
+
+    // The LOCAL player's model is anchored to the known My Spot row — card
+    // OCR must never "correct" it onto another player (misread protection)
+    const { snapshot } = streamService.getGsiState()
+    const localToken = snapshot?.localHeroNpcName
+      ? heroNameToken(snapshot.localHeroNpcName)
+      : null
+    const spotRow = state.mySelectedSpotHeroOrder
+
+    let changed = false
+    let assignments = [...state.modelAssignments]
+    for (const order of state.pickedModelHeroOrders) {
+      const heroName = state.identifiedHeroModelsCache.find(
+        (m) => m.heroOrder === order,
+      )?.heroName
+      const isLocalModel =
+        localToken !== null &&
+        heroName !== undefined &&
+        heroNameToken(heroName) === localToken
+      const ocrRow =
+        isLocalModel && spotRow !== null ? spotRow : ocrRowForPoolHero(order)
+      if (ocrRow === null) continue
+      const existing = assignments.find((a) => a.poolHeroOrder === order)
+      if (!existing) {
+        assignments.push({ poolHeroOrder: order, playerIndex: ocrRow })
+        changed = true
+        logger.info('Model assignment added from card OCR', {
+          order,
+          row: ocrRow,
+        })
+      } else if (existing.playerIndex !== ocrRow) {
+        assignments = assignments.map((a) =>
+          a.poolHeroOrder === order ? { ...a, playerIndex: ocrRow } : a,
+        )
+        changed = true
+        logger.info('Model assignment corrected by card OCR', {
+          order,
+          from: existing.playerIndex,
+          to: ocrRow,
+        })
+      }
+    }
+    if (changed) draftStore.setState({ modelAssignments: assignments })
+    return changed
   }
 
   /**
@@ -403,6 +563,7 @@ export function createAutoRescanService(
     attributionRows: number[] | undefined,
     clockTime: number | null,
     elapsedS: number | null,
+    untimedKind?: 'periodic' | 'model-confirm',
   ): Promise<void> {
     const before = draftStore.getState()
     const prevSelected = before.selectedAbilitiesCache
@@ -429,6 +590,7 @@ export function createAutoRescanService(
 
     acceptedRescans += 1
     attributeModelPicks(prevPendingModels, prevPickedModels, attributionRows)
+    reconcileModelAssignmentsWithOcr()
 
     // Pending tile changes await their persistence confirmation — schedule the
     // fast model-only capture (chains naturally if new changes keep appearing)
@@ -448,12 +610,28 @@ export function createAutoRescanService(
       targeted: heroOrders ?? 'full',
       newPicks: events.length,
       clockTime,
-      ...(elapsedS !== null ? { elapsedS: Math.round(elapsedS) } : { replay: true }),
+      ...(elapsedS !== null
+        ? { elapsedS: Math.round(elapsedS) }
+        : { kind: untimedKind ?? 'untimed' }),
     })
 
     pendingRows.clear()
     fullScanDue = false
     targetRetries = 0
+
+    // One bounded retry for a targeted row whose pick did not show up: the
+    // icon reveal races the capture right after a turn (measured marginal at
+    // +1-2s, loses under CPU load). A model-draft turn also lands here — it
+    // never yields an ability pick, costing at most one extra capture per turn.
+    if (heroOrders && heroOrders.length > 0) {
+      const rowsWithEvents = new Set(events.map((e) => e.playerIndex))
+      for (const row of heroOrders) {
+        if (!rowsWithEvents.has(row) && !retriedEmptyRows.has(row)) {
+          retriedEmptyRows.add(row)
+          pendingRows.add(row)
+        }
+      }
+    }
 
     if (events.length > 0) {
       draftStore.getState().appendPickEvents(events)

--- a/src/main/services/ocr-service.ts
+++ b/src/main/services/ocr-service.ts
@@ -17,9 +17,14 @@ import type { DatabaseService } from './database-service'
 // - One tesseract.js worker, lazily spawned on the first strip batch; strip
 //   recognition is serialized through a queue (tesseract is not reentrant).
 // - Per-row gating keeps the steady-state cost near zero: a row whose strip
-//   bytes are unchanged since the last attempt is skipped, and a row that
-//   already resolved to a confident hero is never OCR'd again this session
-//   (names never change once a model is picked; reset() clears on new drafts).
+//   bytes are unchanged since the last attempt is skipped. A row IS re-OCR'd
+//   when its pixels change — even after resolving — because a resolution can
+//   be a MISREAD (observed 2026-08-26: an empty card read as the wrong hero at
+//   0.933 and, under the old never-re-OCR rule, poisoned attribution for the
+//   whole draft). A changed card re-reads and REPLACES the entry only when the
+//   new read clears the similarity floor; failed reads never wipe a good value.
+//   A card's name area changes pixels only a handful of times per draft, so
+//   the cost stays negligible (reset() clears state on new drafts).
 // - CANDIDATE SCOPING (same trick as pick-slot template matching): a drafted
 //   model can only be one of the draft's 12 pool heroes, so once the initial
 //   scan has identified the pool the roster is narrowed to it. The full roster
@@ -40,6 +45,9 @@ const logger = log.scope('ocr')
 export interface OcrService {
   /** Fire-and-forget: queue name strips from a scan for recognition. */
   processStrips(strips: { row: number; png: ArrayBuffer }[]): void
+  /** Fire-and-forget: OCR a "YOU WILL DRAFT IN: N" digits strip; the parsed
+   * seconds land in DraftStore.draftCountdown stamped with capturedAtMs. */
+  processCountdown(png: ArrayBuffer, capturedAtMs: number): void
   /** Clears per-row state (new draft session). */
   reset(): void
   /** Terminates the tesseract worker (app shutdown). */
@@ -56,7 +64,8 @@ export function createOcrService(
 
   // Per-row gates
   const lastStripHash = new Map<number, string>()
-  const resolvedRows = new Set<number>()
+  /** Countdown strip pixels unchanged -> skip (it changes every second). */
+  let lastCountdownHash: string | null = null
 
   let rosterCache: HeroNameCandidate[] | null = null
   function fullRoster(): HeroNameCandidate[] {
@@ -101,7 +110,7 @@ export function createOcrService(
   }
 
   async function recognizeStrip(row: number, png: Buffer): Promise<void> {
-    if (disposed || resolvedRows.has(row)) return
+    if (disposed) return
     const hash = createHash('md5').update(png).digest('hex')
     if (lastStripHash.get(row) === hash) return
     lastStripHash.set(row, hash)
@@ -125,7 +134,7 @@ export function createOcrService(
     }
     const match = best
 
-    resolvedRows.add(row)
+    const previous = draftStore.getState().ocrHeroNamesByRow[row]
     draftStore.setState((state) => ({
       ocrHeroNamesByRow: {
         ...state.ocrHeroNamesByRow,
@@ -136,11 +145,57 @@ export function createOcrService(
         },
       },
     }))
-    logger.info('OCR hero name resolved', {
-      row,
-      hero: match.name,
-      similarity: Number(match.similarity.toFixed(3)),
-    })
+    if (previous && previous.name !== match.name) {
+      // A changed card overruled an earlier read — usually a misread healing
+      logger.info('OCR hero name revised', {
+        row,
+        from: previous.name,
+        to: match.name,
+        similarity: Number(match.similarity.toFixed(3)),
+      })
+    } else {
+      logger.info('OCR hero name resolved', {
+        row,
+        hero: match.name,
+        similarity: Number(match.similarity.toFixed(3)),
+      })
+    }
+  }
+
+  /**
+   * Digits-only recognition of the countdown strip. Runs inside the same
+   * serialized queue as the name strips; the whitelist is switched to digits
+   * for this recognize and restored after (tesseract is not reentrant, so the
+   * queue guarantees no interleaving).
+   */
+  async function recognizeCountdown(
+    png: Buffer,
+    capturedAtMs: number,
+  ): Promise<void> {
+    if (disposed) return
+    const hash = createHash('md5').update(png).digest('hex')
+    if (lastCountdownHash === hash) return // countdown unchanged since last read
+    lastCountdownHash = hash
+
+    const worker = await getWorker()
+    await worker.setParameters({ tessedit_char_whitelist: '0123456789' })
+    try {
+      const { data } = await worker.recognize(png)
+      const runs = data.text.match(/\d+/g)
+      const seconds = runs ? parseInt(runs[runs.length - 1], 10) : NaN
+      // Max legal countdown: 59s preview + full serpentine schedule (~370s)
+      if (!Number.isFinite(seconds) || seconds < 0 || seconds > 400) {
+        logger.debug('Countdown strip unresolved', {
+          text: data.text.replace(/\n/g, ' | ').slice(0, 40),
+        })
+        return
+      }
+      draftStore.setState({ draftCountdown: { seconds, atMs: capturedAtMs } })
+    } finally {
+      await worker.setParameters({
+        tessedit_char_whitelist: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ ',
+      })
+    }
   }
 
   return {
@@ -159,10 +214,22 @@ export function createOcrService(
       }
     },
 
+    processCountdown(png, capturedAtMs): void {
+      if (disposed) return
+      const buffer = Buffer.from(png)
+      queue = queue
+        .then(() => recognizeCountdown(buffer, capturedAtMs))
+        .catch((error) => {
+          logger.warn('Countdown OCR failed', {
+            error: error instanceof Error ? error.message : String(error),
+          })
+        })
+    },
+
     reset(): void {
       lastStripHash.clear()
-      resolvedRows.clear()
-      draftStore.setState({ ocrHeroNamesByRow: {} })
+      lastCountdownHash = null
+      draftStore.setState({ ocrHeroNamesByRow: {}, draftCountdown: null })
     },
 
     async dispose(): Promise<void> {

--- a/src/main/services/scan-processing-service.ts
+++ b/src/main/services/scan-processing-service.ts
@@ -194,8 +194,8 @@ export function createScanProcessingService(
         // Third consumer: the streamer-view server (caches its own last payload)
         streamService?.onScanProcessed(output.overlayPayload, isInitialScan)
 
-        // Initial scans reset the spot selection — give GSI auto spot detection
-        // a chance to re-apply it from the local player's team slot
+        // Initial scans reset the spot selection — re-arm auto spot/model
+        // detection (row derived from GSI hero x card OCR; see spot-detection)
         if (isInitialScan) spotDetection?.onInitialScanProcessed()
 
         const durationMs = Math.round(performance.now() - start)

--- a/src/main/services/scan-trigger-service.ts
+++ b/src/main/services/scan-trigger-service.ts
@@ -239,6 +239,9 @@ export function createScanTriggerService(
           )
         }
         screenshot ??= await screenshotService.capture()
+        // On-screen state (e.g. the draft countdown) reflects THIS moment, not
+        // when the ML worker finishes — stamp it for time-sensitive consumers
+        const capturedAtMs = Date.now()
 
         const layout = layoutService.getLayout(resolution)
         if (!layout) {
@@ -322,6 +325,11 @@ export function createScanTriggerService(
         // strips queue for recognition (per-row gating keeps this cheap)
         if (isInitialScan) ocrService.reset()
         if (result.nameStrips) ocrService.processStrips(result.nameStrips)
+        // Countdown digits for own-row detection, stamped with the moment the
+        // screenshot was actually taken (the ML pipeline adds seconds)
+        if (result.countdownStrip) {
+          ocrService.processCountdown(result.countdownStrip, capturedAtMs)
+        }
 
         // Model-tile identification (reference library) — log resolved tiles;
         // consumed by diagnostics and compared against W-slot identification

--- a/src/main/services/spot-detection-service.ts
+++ b/src/main/services/spot-detection-service.ts
@@ -3,21 +3,36 @@ import type { StoreApi } from 'zustand/vanilla'
 import type { DraftStore } from '../store/draft-store'
 import type { WindowManager } from './window-manager'
 import type { StreamServerService } from './stream-server-service'
+import {
+  resolveOwnRowFromOcr,
+  heroNameToken,
+} from '@core/domain/own-row-detection'
 
 // @DEV-GUIDE: Auto "My Spot" + "My Model" selection from GSI while PLAYING (not
 // spectating) — the automated replacement for the overlay's manual buttons (which
 // are hidden when automatic draft tracking is enabled).
-// - Spot: the GSI player block carries team_name + team_slot, which the parser maps
-//   to the scan's player index (0-4 radiant, 5-9 dire) as localPlayer.slotIndex.
+// - Spot: NO GSI field matches the draft screen's visual row order (team_slot and
+//   player_slot are both lobby-order — disproven on live games 2026-08-25; only
+//   the team half is trustworthy). Two screen-side signals derive it instead:
+//   1. Draft countdown (INSTANT — lands seconds into the preview): auto-rescan
+//      matches the OCR'd "YOU WILL DRAFT IN: N" against the turn schedule and
+//      publishes DraftStore.countdownSpotRow. Validated 4/4 across slots on
+//      live lobby games 2026-08-26 (deltas 1.5-2.1s; the 2.5s matcher tolerance
+//      can never straddle two 7s-spaced turns).
+//   2. GSI hero block x card-name OCR (lands after the user DRAFTS their model,
+//      near-certain): resolveOwnRowFromOcr over DraftStore.ocrHeroNamesByRow.
+//      It CONFIRMS the countdown pick (fills in the model's dbHeroId, no UI
+//      churn) or CORRECTS it (re-broadcast).
+//   Every GSI snapshot retries both while armed.
 // - Model: once the user picks their hero, GSI's hero block reports it as an npc
-//   short name (localHeroNpcName); matched against the identified pool heroes by
-//   DB name (npc name minus underscores — same convention as stream-server).
+//   short name (localHeroNpcName); matched against the identified pool heroes
+//   via heroNameToken (underscore-normalized + npc aliases, e.g. zuus->zeus).
 //
-// Each selection applies at most ONCE per initial scan (the scan-processor resets
+// Each signal applies at most ONCE per initial scan (the scan-processor resets
 // selections on every initial scan, and scan-processing-service calls
-// onInitialScanProcessed): immediately when GSI already knows the value, or on a
-// later GSI snapshot when it arrives (the model typically lands mid-draft). A
-// manual deselect after auto-selection is respected (the once-flags stay set).
+// onInitialScanProcessed). A manual selection disables both signals; a manual
+// deselect of an auto pick is respected by the signal that made it — but the
+// OCR signal, if still pending, will place its authoritative row once.
 //
 // Selection mirrors the draft:selectMySpot/selectMyModel IPC handlers exactly:
 // DraftStore update + broadcast to both windows.
@@ -34,11 +49,15 @@ export function createSpotDetectionService(
   windowManager: WindowManager,
   streamService: Pick<StreamServerService, 'getGsiState' | 'onGsiSnapshot'>,
 ): SpotDetectionService {
-  /** True once the respective auto-selection ran for this initial scan generation. */
-  let spotApplied = false
+  /** Once-flags per initial-scan generation (see DEV-GUIDE). */
+  let countdownApplied = false
+  let ocrApplied = false
   let modelApplied = false
   /** True between an initial scan and the auto-selection attempts succeeding. */
   let armed = false
+  /** Row this service last auto-applied — distinguishes our own selection from
+   * a manual one (only our own may be corrected by the OCR signal). */
+  let autoAppliedRow: number | null = null
 
   function broadcast(channel: string, payload: unknown): void {
     const cp = windowManager.getControlPanelWindow()
@@ -47,37 +66,91 @@ export function createSpotDetectionService(
     if (overlay && !overlay.isDestroyed()) overlay.webContents.send(channel, payload)
   }
 
-  function trySelectSpot(): void {
-    if (spotApplied) return
+  function applySpot(dbHeroId: number | null, row: number): void {
+    draftStore.getState().selectMySpot(dbHeroId, row)
+    autoAppliedRow = row
+    broadcast('draft:selectMySpot', { selectedHeroOrderForDrafting: row })
+  }
+
+  function trySelectSpotFromCountdown(): void {
+    if (countdownApplied || ocrApplied) return
 
     const state = draftStore.getState()
-    if (state.identifiedHeroModelsCache.length === 0) return
-    if (state.mySelectedSpotHeroOrder !== null) return
-
-    const { snapshot, connected } = streamService.getGsiState()
-    const slotIndex = snapshot?.localPlayer?.slotIndex ?? null
-    if (!connected || slotIndex === null) return
-
-    const hero = state.identifiedHeroModelsCache.find(
-      (m) => m.heroOrder === slotIndex,
-    )
-    if (!hero || hero.dbHeroId === null) {
-      // Row not identified — a corrected initial rescan re-arms via
-      // onInitialScanProcessed, so don't burn the once-flag on this
-      logger.warn('GSI knows the spot but its hero row is unidentified', {
-        slotIndex,
-      })
+    if (state.mySelectedSpotHeroOrder !== null) {
+      // Selected before we got a reading (manual, or OCR won the race) —
+      // this signal's work is done for the draft
+      countdownApplied = true
       return
     }
 
-    spotApplied = true
-    draftStore.getState().selectMySpot(hero.dbHeroId, slotIndex)
-    logger.info('My Spot auto-selected from GSI', {
-      slotIndex,
-      hero: hero.heroDisplayName,
-      player: snapshot?.localPlayer?.name,
+    const candidate = state.countdownSpotRow
+    if (candidate === null) return
+
+    countdownApplied = true
+    applySpot(null, candidate.row)
+    logger.info('My Spot auto-selected (draft countdown)', {
+      row: candidate.row,
+      deltaS: Number(candidate.deltaS.toFixed(1)),
     })
-    broadcast('draft:selectMySpot', { selectedHeroOrderForDrafting: slotIndex })
+  }
+
+  function trySelectSpotFromOcr(): void {
+    if (ocrApplied) return
+
+    const state = draftStore.getState()
+    const current = state.mySelectedSpotHeroOrder
+    if (current !== null && current !== autoAppliedRow) {
+      // Manually selected (fresh, or over our auto pick) — never fight the user
+      ocrApplied = true
+      return
+    }
+
+    const { snapshot, connected } = streamService.getGsiState()
+    const npcName = snapshot?.localHeroNpcName ?? null
+    if (!connected || !npcName) return
+
+    // slotIndex (team_name + team_slot) is lobby-order — only its team HALF is
+    // meaningful; the visual row comes from the OCR match below
+    const slotIndex = snapshot?.localPlayer?.slotIndex ?? null
+    const teamHalfStart = slotIndex === null ? null : slotIndex < 5 ? 0 : 5
+
+    const row = resolveOwnRowFromOcr({
+      ocrHeroNamesByRow: state.ocrHeroNamesByRow,
+      localHeroNpcName: npcName,
+      teamHalfStart,
+    })
+    // Model not on a card yet / not OCR'd yet — every snapshot retries
+    if (row === null) return
+
+    const token = heroNameToken(npcName)
+    const poolHero = state.identifiedHeroModelsCache.find(
+      (m) => heroNameToken(m.heroName) === token,
+    )
+    const dbHeroId = poolHero?.dbHeroId ?? null
+
+    ocrApplied = true
+    if (current === row) {
+      // Countdown pick confirmed — just fill in the hero id, no UI churn
+      draftStore.getState().selectMySpot(dbHeroId, row)
+      logger.info('My Spot confirmed (GSI model x card OCR)', {
+        row,
+        model: npcName,
+      })
+      return
+    }
+    applySpot(dbHeroId, row)
+    logger.info(
+      current === null
+        ? 'My Spot auto-selected (GSI model x card OCR)'
+        : 'My Spot corrected by OCR (countdown pick was wrong)',
+      {
+        row,
+        previousRow: current,
+        model: npcName,
+        teamHalfStart,
+        player: snapshot?.localPlayer?.name,
+      },
+    )
   }
 
   function trySelectModel(): void {
@@ -91,10 +164,9 @@ export function createSpotDetectionService(
     const npcName = snapshot?.localHeroNpcName ?? null
     if (!connected || !npcName) return
 
-    // npc short name -> DB hero name convention: underscores stripped
-    const dbName = npcName.replace(/_/g, '')
+    const token = heroNameToken(npcName)
     const model = state.identifiedHeroModelsCache.find(
-      (m) => m.heroName === dbName,
+      (m) => heroNameToken(m.heroName) === token,
     )
     if (!model || model.dbHeroId === null) {
       logger.warn('GSI reported a picked model outside the identified pool', {
@@ -114,19 +186,23 @@ export function createSpotDetectionService(
 
   function tryApply(): void {
     if (!armed) return
-    trySelectSpot()
+    trySelectSpotFromCountdown()
+    trySelectSpotFromOcr()
     trySelectModel()
-    if (spotApplied && modelApplied) armed = false
+    if (ocrApplied && modelApplied) armed = false
   }
 
-  // GSI learns things over time (the model pick lands mid-draft; the server may
-  // start late) — every snapshot is a cheap retry while armed.
+  // GSI learns things over time (the countdown lands during the preview, the
+  // model pick mid-draft; the server may start late) — every snapshot is a
+  // cheap retry while armed.
   streamService.onGsiSnapshot(() => tryApply())
 
   return {
     onInitialScanProcessed(): void {
-      spotApplied = false
+      countdownApplied = false
+      ocrApplied = false
       modelApplied = false
+      autoAppliedRow = null
       armed = true
       tryApply()
     },

--- a/src/main/services/stream-server-service.ts
+++ b/src/main/services/stream-server-service.ts
@@ -84,6 +84,7 @@ export function createStreamServerService(
   getPickEvents?: () => PickEvent[],
   getModelAssignments?: () => Array<{ poolHeroOrder: number; playerIndex: number }>,
   getSlotRowMappings?: () => Array<{ gsiSlot: number; scanRow: number }>,
+  getLocalPlayerRow?: () => number | null,
 ): StreamServerService {
   let server: Server | null = null
   let activePort: number | null = null
@@ -150,18 +151,17 @@ export function createStreamServerService(
           }
         }
       }
-      // Playing: GSI only knows the LOCAL player (name via team_slot, model via
-      // the hero block) — merge them so the board isn't all placeholders
+      // Playing: GSI only knows the LOCAL player. Placement uses the OCR-derived
+      // My Spot row (own-row-detection.ts) — localPlayer.slotIndex is lobby-order
+      // and does NOT match the draft screen, so until the row is derived the
+      // local name shows nowhere rather than on a probably-wrong row (same
+      // principle as the spectate slot-row mappings).
       const local = gsiSnapshot.localPlayer
-      if (
-        local &&
-        local.slotIndex !== null &&
-        local.slotIndex >= 0 &&
-        local.slotIndex < 10
-      ) {
-        playerNames[local.slotIndex] ??= local.name
-        if (gsiSnapshot.localHeroNpcName && !playerModels[local.slotIndex]) {
-          playerModels[local.slotIndex] = {
+      const localRow = getLocalPlayerRow?.() ?? null
+      if (local && localRow !== null && localRow >= 0 && localRow < 10) {
+        playerNames[localRow] ??= local.name
+        if (gsiSnapshot.localHeroNpcName && !playerModels[localRow]) {
+          playerModels[localRow] = {
             npcName: gsiSnapshot.localHeroNpcName,
             displayName: heroDisplayName(gsiSnapshot.localHeroNpcName),
           }

--- a/src/main/services/window-manager.ts
+++ b/src/main/services/window-manager.ts
@@ -238,13 +238,23 @@ export function createWindowManager(): WindowManager {
   }
 
   /**
-   * Re-applies the CURRENT click-through state. Mouse-move forwarding is
-   * fragile on Windows — window operations can silently drop it, leaving
-   * hover-only overlay elements dead. Cheap and idempotent, so callers re-arm
-   * it after anything that disturbs the window (notably a completed scan,
-   * which repaints the whole hotspot layer).
+   * Re-arms mouse-move forwarding. Fragile on Windows — window operations can
+   * silently drop it, leaving hover-only overlay elements dead. A same-state
+   * re-apply demonstrably does NOT restore it (observed 2026-08-26: tooltips
+   * stayed dead after the auto initial scan despite the post-scan refresh,
+   * until a button hover toggled click-through off and back on) — so when the
+   * overlay is in click-through mode this performs that full toggle CYCLE:
+   * ignore off, then back on with forwarding. The off state lasts only between
+   * the two synchronous calls. While the user is interacting (ignore already
+   * false) the current state is simply re-applied — never yank click-through
+   * off under the cursor.
    */
   function refreshOverlayMouseEvents(): void {
+    if (mouseIgnore) {
+      applyOverlayMouseEvents(false, mouseForward)
+      applyOverlayMouseEvents(true, mouseForward)
+      return
+    }
     applyOverlayMouseEvents(mouseIgnore, mouseForward)
   }
 

--- a/src/main/store/draft-store.ts
+++ b/src/main/store/draft-store.ts
@@ -63,6 +63,13 @@ export interface DraftSessionSlice {
     number,
     { name: string; displayName: string; similarity: number }
   >
+  /** Latest OCR'd "YOU WILL DRAFT IN" seconds + its capture time (playing
+   * mode; countdown-based own-row detection). */
+  draftCountdown: { seconds: number; atMs: number } | null
+  /** Own row derived from the countdown vs the turn schedule (auto-rescan
+   * computes it — it owns the pick-phase anchor; spot-detection consumes).
+   * Validated 4/4 on live lobby games 2026-08-26. */
+  countdownSpotRow: { row: number; deltaS: number; atMs: number } | null
 }
 
 /** A picked hero model attributed to the player who drafted it. */
@@ -107,6 +114,8 @@ export function createDraftStore() {
     gsiHeroEvents: [],
     slotRowMappings: [],
     ocrHeroNamesByRow: {},
+    draftCountdown: null,
+    countdownSpotRow: null,
 
     // Actions
     resetSession: () =>
@@ -131,6 +140,8 @@ export function createDraftStore() {
         gsiHeroEvents: [],
         slotRowMappings: [],
         ocrHeroNamesByRow: {},
+        draftCountdown: null,
+        countdownSpotRow: null,
       }),
 
     selectMySpot: (dbHeroId, heroOrder) =>

--- a/src/main/workers/ml-worker.ts
+++ b/src/main/workers/ml-worker.ts
@@ -30,6 +30,11 @@ import { matchModelTile } from '@core/ml/model-tile-matcher'
 import {
   MODEL_TILE_COMPARE_SIZE,
   PLAYER_CARD_COMPARE_SIZE,
+  COUNTDOWN_REGION_X_OFFSET_RATIO,
+  COUNTDOWN_REGION_WIDTH_RATIO,
+  COUNTDOWN_REGION_Y_RATIO,
+  COUNTDOWN_REGION_HEIGHT_RATIO,
+  COUNTDOWN_STRIP_TARGET_WIDTH,
   PICK_TEMPLATE_COMPARE_SIZE,
   PICK_TEMPLATE_CROP_INSET_RATIO,
   PICK_TEMPLATE_FALLBACK_MIN_NCC,
@@ -346,6 +351,8 @@ async function handleScan(payload: {
   const playerCardTiles = await capturePlayerCardTiles(screenshot, coords)
   // Hero-name strips for main-process OCR (upscaled grayscale PNGs)
   const nameStrips = await captureNameStrips(screenshot, coords)
+  // "YOU WILL DRAFT IN" digits for countdown-based own-row detection
+  const countdownStrip = await captureCountdownStrip(screenshot)
   // Model-tile identification against the reference library (no-op until the
   // gather script's models mode populates it) — MUST run before the tiles'
   // buffers are transferred away below
@@ -358,6 +365,7 @@ async function handleScan(payload: {
     modelTiles,
     playerCardTiles,
     nameStrips,
+    countdownStrip,
     poolRetryResults,
     modelTileMatches,
   }
@@ -365,6 +373,7 @@ async function handleScan(payload: {
     ...(modelTiles?.map((t) => t.tile) ?? []),
     ...(playerCardTiles?.map((t) => t.tile) ?? []),
     ...(nameStrips?.map((s) => s.png) ?? []),
+    ...(countdownStrip ? [countdownStrip] : []),
   ])
 }
 
@@ -463,6 +472,34 @@ async function captureNameStrips(
 }
 
 /**
+ * Crops the "YOU WILL DRAFT IN: N" digits region (playing mode) as an upscaled
+ * grayscale PNG. The region is computed from screenshot DIMENSIONS, not the
+ * layout preset: the HUD line is center-anchored and scales with height, and
+ * the digits render left-anchored right after the fixed-width label text.
+ * Spectate/replay screens have no countdown — OCR simply finds no digits.
+ */
+async function captureCountdownStrip(
+  screenshot: DecodedScreenshot,
+): Promise<ArrayBuffer | undefined> {
+  const { width, height } = screenshot
+  const region = {
+    x: Math.round(width / 2 + height * COUNTDOWN_REGION_X_OFFSET_RATIO),
+    y: Math.round(height * COUNTDOWN_REGION_Y_RATIO),
+    width: Math.round(height * COUNTDOWN_REGION_WIDTH_RATIO),
+    height: Math.round(height * COUNTDOWN_REGION_HEIGHT_RATIO),
+  }
+  if (region.x + region.width > width || region.y + region.height > height) {
+    return undefined
+  }
+  try {
+    const png = await cropRegionPng(screenshot, region, COUNTDOWN_STRIP_TARGET_WIDTH)
+    return png.buffer.slice(png.byteOffset, png.byteOffset + png.byteLength)
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Identifies the 12 model tiles against the reference-tile library. Reuses the
  * raw tiles already captured for diff detection — no extra cropping.
  */
@@ -510,7 +547,19 @@ async function performInitialScan(
   return {
     ultimates,
     standard,
-    selectedAbilities: [],
+    // Nothing is picked at draft start, so the boxes are not SCANNED — but
+    // their default (empty) slots must exist in the payload so the overlay
+    // renders their hotspots from the first scan: the My Spot border shows on
+    // the (empty) boxes as soon as the spot is known, not after the first pick.
+    // Coords carry x/y only — the shared box size lives in the params (same
+    // merge performSelectedAbilitiesScan does).
+    selectedAbilities: (coords.selected_abilities_coords ?? []).map((c) =>
+      makeDefaultResult({
+        ...c,
+        width: coords.selected_abilities_params?.width ?? c.width,
+        height: coords.selected_abilities_params?.height ?? c.height,
+      }),
+    ),
     heroDefiningAbilities,
   }
 }

--- a/src/renderer/overlay/src/hooks/use-overlay-data.ts
+++ b/src/renderer/overlay/src/hooks/use-overlay-data.ts
@@ -63,17 +63,12 @@ export function useOverlayData(): OverlayState & {
         setScanState('scanned')
         setScanError(null)
       }
-      // Sync selections from payload
-      if (data.selectedHeroForDraftingDbId !== undefined) {
-        // Resolve hero order from heroesForMySpotUI
-        if (data.selectedHeroForDraftingDbId === null) {
-          setSelectedSpotHeroOrder(null)
-        } else {
-          const hero = data.heroesForMySpotUI.find(
-            (h) => h.dbHeroId === data.selectedHeroForDraftingDbId,
-          )
-          if (hero) setSelectedSpotHeroOrder(hero.heroOrder)
-        }
+      // Sync selections from payload. The PLAYER row comes through directly —
+      // never resolve the dbId against heroesForMySpotUI (pool rows): the dbId
+      // is the MODEL hero, and pool row != player row (that lookup put the
+      // My Spot highlight on the wrong player's boxes — 2026-08-26).
+      if (data.selectedSpotHeroOrder !== undefined) {
+        setSelectedSpotHeroOrder(data.selectedSpotHeroOrder)
       }
       if (data.selectedModelHeroOrder !== undefined) {
         setSelectedModelHeroOrder(data.selectedModelHeroOrder)

--- a/src/shared/constants/thresholds.ts
+++ b/src/shared/constants/thresholds.ts
@@ -121,6 +121,18 @@ export const OCR_STRIP_DIFF_THRESHOLD = 4
 // across game resolutions (tesseract reads upscaled small text far better).
 export const OCR_STRIP_TARGET_WIDTH = 600
 
+// "YOU WILL DRAFT IN: N" countdown digits (playing mode; countdown-based
+// own-row detection — countdownTargetRow in core/gsi/draft-clock.ts). The HUD
+// line is center-anchored and scales with screen HEIGHT; the label text ends at
+// a fixed offset right of center and the digits render left-anchored after it.
+// Ratios are of screen HEIGHT, measured on 2560x1440 screenshots (2026-08-26);
+// the x offset is added to width/2.
+export const COUNTDOWN_REGION_X_OFFSET_RATIO = 0.07
+export const COUNTDOWN_REGION_WIDTH_RATIO = 0.12
+export const COUNTDOWN_REGION_Y_RATIO = 0.088
+export const COUNTDOWN_REGION_HEIGHT_RATIO = 0.05
+export const COUNTDOWN_STRIP_TARGET_WIDTH = 300
+
 // Picked-model detection via model-tile diffing. The 12 model portrait tiles on
 // the draft stage are pixel-STATIC while unpicked (measured mean abs diff 0.0
 // across scans) and change drastically when picked (measured 35-120). Tiles are
@@ -157,8 +169,11 @@ export const AUTO_INITIAL_SCAN_DELAY_S = 15
 // so a 1s tick costs nothing between turns but keeps boundary latency low.
 export const AUTO_RESCAN_TICK_MS = 1_000
 // Wait after a turn ends before scanning — the game UI needs a moment to render
-// the picked ability icon into the player's row.
-export const AUTO_RESCAN_PICK_VISIBLE_DELAY_S = 1
+// the picked ability icon into the player's row. Measured 2026-08-26: at 1s the
+// reveal races the capture (misses under CPU load); 2s clears it with 5s of the
+// next turn to spare. A row whose targeted scan still comes up empty gets one
+// retry a tick later (see runRescan).
+export const AUTO_RESCAN_PICK_VISIBLE_DELAY_S = 2
 // A targeted rescan blocked by the contamination guard (hover tooltip over the
 // rows) retries every tick; after this many attempts the pending rows are
 // dropped — the next round-break full reconciliation scan will catch the pick.

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -140,6 +140,9 @@ export interface OverlayDataPayload {
   heroModels: HeroModelDisplay[]
   heroesForMySpotUI: HeroSpotDisplay[]
   selectedHeroForDraftingDbId: number | null
+  /** My Spot PLAYER row 0-9 (authoritative — the dbId above is the MODEL hero
+   * and must not be resolved against pool rows; see spot-detection-service). */
+  selectedSpotHeroOrder: number | null
   selectedModelHeroOrder: number | null
   heroesCoords: SlotCoordinate[]
   heroesParams: { width: number; height: number }

--- a/src/shared/types/ml.ts
+++ b/src/shared/types/ml.ts
@@ -123,6 +123,14 @@ export interface MlWorkerSuccessResponse {
    * layout has no heroes_coords.
    */
   nameStrips?: { row: number; png: ArrayBuffer }[]
+  /**
+   * The "YOU WILL DRAFT IN: N" digits region (playing mode) as an upscaled
+   * grayscale PNG for OCR in the main process — feeds countdown-based own-row
+   * detection (core/gsi/draft-clock.ts countdownTargetRow). Region is computed
+   * from the screenshot dimensions (HUD is center-anchored and scales with
+   * height), not from the layout preset. Buffer is transferred.
+   */
+  countdownStrip?: ArrayBuffer
   /** Results for payload.retryPoolSlots (only slots that were re-read). */
   poolRetryResults?: ScanResult[]
   /**

--- a/tests/unit/core/domain/own-row-detection.test.ts
+++ b/tests/unit/core/domain/own-row-detection.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveOwnRowFromOcr,
+  heroNameToken,
+} from '@core/domain/own-row-detection'
+
+function ocr(byRow: Record<number, string>): Record<number, { name: string }> {
+  return Object.fromEntries(
+    Object.entries(byRow).map(([row, name]) => [row, { name }]),
+  )
+}
+
+describe('heroNameToken', () => {
+  it('strips underscores from GSI npc short names', () => {
+    expect(heroNameToken('drow_ranger')).toBe('drowranger')
+    expect(heroNameToken('vengefulspirit')).toBe('vengefulspirit')
+    expect(heroNameToken('keeper_of_the_light')).toBe('keeperofthelight')
+  })
+
+  it('normalizes DB names that KEEP underscores (monkey_king)', () => {
+    expect(heroNameToken('monkey_king')).toBe(heroNameToken('monkeyking'))
+  })
+
+  it('bridges the zuus/zeus npc divergence (only alias in the 127-hero DB)', () => {
+    expect(heroNameToken('zuus')).toBe('zeus')
+    expect(heroNameToken('zeus')).toBe('zeus')
+  })
+
+  it('leaves npc-based DB names alone (necrolyte, obsidiandestroyer)', () => {
+    expect(heroNameToken('necrolyte')).toBe('necrolyte')
+    expect(heroNameToken('obsidian_destroyer')).toBe('obsidiandestroyer')
+  })
+})
+
+describe('resolveOwnRowFromOcr', () => {
+  // The two live games that motivated this module (2026-08-25)
+  it('resolves the dire game: drow_ranger on row 5', () => {
+    expect(
+      resolveOwnRowFromOcr({
+        ocrHeroNamesByRow: ocr({
+          0: 'gyrocopter',
+          4: 'juggernaut',
+          5: 'drowranger',
+          6: 'enchantress',
+          7: 'snapfire',
+        }),
+        localHeroNpcName: 'drow_ranger',
+        teamHalfStart: 5,
+      }),
+    ).toBe(5)
+  })
+
+  it('resolves the radiant game: vengefulspirit on row 3', () => {
+    expect(
+      resolveOwnRowFromOcr({
+        ocrHeroNamesByRow: ocr({ 3: 'vengefulspirit', 5: 'necrolyte', 6: 'rubick' }),
+        localHeroNpcName: 'vengefulspirit',
+        teamHalfStart: 0,
+      }),
+    ).toBe(3)
+  })
+
+  // The lobby game where the raw-strip comparison failed (2026-08-26)
+  it('resolves Zeus through the zuus alias', () => {
+    expect(
+      resolveOwnRowFromOcr({
+        ocrHeroNamesByRow: ocr({ 5: 'zeus', 6: 'enchantress' }),
+        localHeroNpcName: 'zuus',
+        teamHalfStart: 5,
+      }),
+    ).toBe(5)
+  })
+
+  it('resolves DB names with underscores (monkey_king)', () => {
+    expect(
+      resolveOwnRowFromOcr({
+        ocrHeroNamesByRow: ocr({ 2: 'monkey_king' }),
+        localHeroNpcName: 'monkey_king',
+        teamHalfStart: 0,
+      }),
+    ).toBe(2)
+  })
+
+  it('returns null when the model has not been OCRd on any card yet', () => {
+    expect(
+      resolveOwnRowFromOcr({
+        ocrHeroNamesByRow: ocr({ 0: 'gyrocopter' }),
+        localHeroNpcName: 'drow_ranger',
+        teamHalfStart: 5,
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when the OCR map is empty', () => {
+    expect(
+      resolveOwnRowFromOcr({
+        ocrHeroNamesByRow: {},
+        localHeroNpcName: 'drow_ranger',
+        teamHalfStart: null,
+      }),
+    ).toBeNull()
+  })
+
+  it('refuses an ambiguous duplicate OCR read', () => {
+    expect(
+      resolveOwnRowFromOcr({
+        ocrHeroNamesByRow: ocr({ 5: 'drowranger', 8: 'drowranger' }),
+        localHeroNpcName: 'drow_ranger',
+        teamHalfStart: 5,
+      }),
+    ).toBeNull()
+  })
+
+  it('vetoes a match outside the known team half (OCR misread guard)', () => {
+    expect(
+      resolveOwnRowFromOcr({
+        ocrHeroNamesByRow: ocr({ 2: 'drowranger' }),
+        localHeroNpcName: 'drow_ranger',
+        teamHalfStart: 5,
+      }),
+    ).toBeNull()
+  })
+
+  it('accepts a match anywhere when the team half is unknown', () => {
+    expect(
+      resolveOwnRowFromOcr({
+        ocrHeroNamesByRow: ocr({ 7: 'templarassassin' }),
+        localHeroNpcName: 'templar_assassin',
+        teamHalfStart: null,
+      }),
+    ).toBe(7)
+  })
+
+  it('ignores out-of-range rows', () => {
+    expect(
+      resolveOwnRowFromOcr({
+        ocrHeroNamesByRow: ocr({ 11: 'drowranger' }),
+        localHeroNpcName: 'drow_ranger',
+        teamHalfStart: null,
+      }),
+    ).toBeNull()
+  })
+})

--- a/tests/unit/core/gsi/draft-clock.test.ts
+++ b/tests/unit/core/gsi/draft-clock.test.ts
@@ -4,6 +4,7 @@ import {
   turnAt,
   turnsEndedBetween,
   isRoundBreak,
+  countdownTargetRow,
 } from '@core/gsi/draft-clock'
 
 // Small config for arithmetic-friendly tests: 4 players (2 per team), 5s turns,
@@ -108,5 +109,45 @@ describe('isRoundBreak', () => {
     expect(isRoundBreak(22.9, schedule)).toBe(true)
     expect(isRoundBreak(43, schedule)).toBe(true)
     expect(isRoundBreak(9999, schedule)).toBe(true)
+  })
+})
+
+describe('countdownTargetRow', () => {
+  // Default AD schedule: [0,5,1,6,2,7,3,8,4,9], 7s turns, first turn at 0s
+  it('resolves the TA game reading: N=86 at 51s before draft start -> row 7', () => {
+    const result = countdownTargetRow({ countdownS: 86, elapsedS: -51 })
+    expect(result?.row).toBe(7) // 86-51 = 35 = index 5 -> order[5] = 7
+  })
+
+  it('resolves the Venge game reading: N=33 at 9s after draft start -> row 3', () => {
+    const result = countdownTargetRow({ countdownS: 33, elapsedS: 9 })
+    expect(result?.row).toBe(3) // 33+9 = 42 = index 6 -> order[6] = 3
+  })
+
+  it('resolves row 0 (first pick) from a preview reading', () => {
+    const result = countdownTargetRow({ countdownS: 40, elapsedS: -40 })
+    expect(result?.row).toBe(0)
+  })
+
+  it('tolerates ~2s of combined OCR/anchor error', () => {
+    // Turn index 5 starts at 35s; row = order[5] = 7
+    expect(countdownTargetRow({ countdownS: 36, elapsedS: 0 })?.row).toBe(7)
+    expect(countdownTargetRow({ countdownS: 34, elapsedS: 0 })?.row).toBe(7)
+  })
+
+  it('refuses a reading that lands between turn starts', () => {
+    // 3.5s off every turn start (starts are multiples of 7 in round 1)
+    expect(countdownTargetRow({ countdownS: 24.5, elapsedS: 0 })).toBeNull()
+  })
+
+  it('resolves later-round targets across round breaks', () => {
+    // Round 2 starts at 75s (70 + 5s break), first turn is row 9
+    const result = countdownTargetRow({ countdownS: 55, elapsedS: 20 })
+    expect(result?.row).toBe(9)
+  })
+
+  it('returns the exact-match delta', () => {
+    const result = countdownTargetRow({ countdownS: 14, elapsedS: 0 })
+    expect(result).toEqual({ row: 1, deltaS: 0 })
   })
 })

--- a/tests/unit/renderer/overlay/use-overlay-data.test.ts
+++ b/tests/unit/renderer/overlay/use-overlay-data.test.ts
@@ -55,6 +55,7 @@ function makeOverlayPayload(overrides: Partial<OverlayDataPayload> = {}): Overla
     heroModels: [],
     heroesForMySpotUI: [],
     selectedHeroForDraftingDbId: null,
+    selectedSpotHeroOrder: null,
     selectedModelHeroOrder: null,
     heroesCoords: [],
     heroesParams: { width: 358, height: 170 },
@@ -165,46 +166,38 @@ describe('useOverlayData', () => {
       expect(result.current.scanState).toBe('idle')
     })
 
-    it('syncs selectedSpotHeroOrder from payload hero match', () => {
+    it('syncs selectedSpotHeroOrder from the payload row directly', () => {
       const { result } = renderHook(() => useOverlayData())
+      // The dbId is the MODEL hero and must NOT be resolved against the pool
+      // list (pool row != player row); the payload row wins
       const payload = makeOverlayPayload({
         selectedHeroForDraftingDbId: 42,
+        selectedSpotHeroOrder: 7,
         heroesForMySpotUI: [
           { heroOrder: 3, heroName: 'npc_dota_hero_axe', dbHeroId: 42 },
-          { heroOrder: 7, heroName: 'npc_dota_hero_lina', dbHeroId: 55 },
         ],
       })
 
       act(() => emit('overlay:data', payload))
 
-      expect(result.current.selectedSpotHeroOrder).toBe(3)
+      expect(result.current.selectedSpotHeroOrder).toBe(7)
     })
 
-    it('clears selectedSpotHeroOrder when selectedHeroForDraftingDbId is null', () => {
+    it('clears selectedSpotHeroOrder when the payload row is null', () => {
       const { result } = renderHook(() => useOverlayData())
 
-      // First select a hero
       act(() =>
         emit(
           'overlay:data',
-          makeOverlayPayload({
-            selectedHeroForDraftingDbId: 42,
-            heroesForMySpotUI: [
-              { heroOrder: 3, heroName: 'npc_dota_hero_axe', dbHeroId: 42 },
-            ],
-          }),
+          makeOverlayPayload({ selectedSpotHeroOrder: 3 }),
         ),
       )
       expect(result.current.selectedSpotHeroOrder).toBe(3)
 
-      // Then clear it
       act(() =>
         emit(
           'overlay:data',
-          makeOverlayPayload({
-            selectedHeroForDraftingDbId: null,
-            heroesForMySpotUI: [],
-          }),
+          makeOverlayPayload({ selectedSpotHeroOrder: null }),
         ),
       )
       expect(result.current.selectedSpotHeroOrder).toBeNull()


### PR DESCRIPTION
## Problem

Spot recognition in live (playing) games was wrong — "people are shuffled". Root cause, established across multiple live games with ground truth: **no GSI field matches the draft screen's visual row order**. `team_slot` and `player_slot` are lobby-order (e.g. one game: visual row 3, team_slot 2, player_slot 3; another: visual row 5, team_slot 3, player_slot 8). Only the team half (`team_name`) is trustworthy — the same non-derivable permutation previously proven for spectate/replay. My Spot, the local name on the streamer view, and model attribution all landed on wrong rows.

## Fix: two screen-side signals (playing mode)

1. **Draft countdown (instant).** The "YOU WILL DRAFT IN: N" digits are OCR'd from every scan (region computed from screenshot dimensions — HUD is center-anchored and scales with height) and matched against the serpentine turn schedule via the pick-phase anchor (`countdownTargetRow`, core/gsi/draft-clock.ts). Commits the spot **during the preview**, before any pick. Live-validated 6+ games across radiant/dire slots (deltas 0.9–2.3s vs a 2.5s tolerance; turn starts are 7s apart, so no ambiguity is possible).
2. **GSI hero block × card-name OCR (near-certain).** Fires when the user drafts their model: the drafted hero's name on a player card pins the row (`resolveOwnRowFromOcr`, core/domain/own-row-detection.ts). It confirms the countdown pick (fills in the model's dbHeroId silently) or corrects it (re-broadcast). Hero-name comparison is underscore-normalized with npc aliases — a full audit of all 127 DB heroes found `zuus→zeus` is the only true divergence.

Manual selection still overrides everything; manual deselect of an auto pick is respected.

## Also fixed along the way

- **Overlay highlight on the wrong player** — the overlay resolved the spot's dbHeroId against the 12-hero *pool* list (pool row ≠ player row). The payload now carries `selectedSpotHeroOrder` directly.
- **Model→row attribution** — card OCR is now the authoritative source (turn timing as fallback while OCR is pending), with a reconcile pass that appends/corrects assignments when OCR lands late. The local player's model is anchored to the known spot row so a single card misread can never move it (observed live: an 0.933-similarity misread put a model on the wrong team's row).
- **OCR misread healing** — rows re-OCR when their card pixels change instead of locking on first resolution; replacements require clearing the similarity floor, and overrides log as `OCR hero name revised`.
- **My Spot border timing** — the initial scan now seeds default empty pick-box slots, so the border shows on the (empty) boxes the moment the spot commits, not after the first pick.
- **Dead hover after auto scans** — the post-scan mouse refresh now performs a real click-through toggle cycle; Windows drops mouse-move forwarding on layered-state rebuilds and a same-state re-apply demonstrably does not restore it.
- **Pick-scan timing** — visibility delay 1s→2s (the icon reveal races the capture at +1s, losing under CPU load) plus one bounded retry for a targeted row whose pick hadn't rendered.
- **False anchor on mid-draft join** — anchoring now requires having seen the preview ramp (clock ≤ −8; per-turn countdowns only reach −7); joining a draft in progress falls back to periodic full rescans.
- Misleading `replay: true` log field on untimed scans replaced with `kind: 'model-confirm' | 'periodic'`.

## Validation

- 656/656 unit tests (new: `own-row-detection.test.ts`, `countdownTargetRow` cases including real-game readings), typecheck and lint clean.
- Live lobby validation across all tested seat positions (dire 4, radiant 5, radiant 1, dire 5, radiant 3, radiant 1): countdown row correct pre-pick in every game, confirmed manually; OCR confirm/correct path exercised both ways; a full draft tracked with **zero** round-break stragglers and all 10 models attributed; streamer view confirmed identical to the in-game board end-to-end.

Not for release yet — more changes planned before the next version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
