### PR TITLE
chore: Twitch-extension roadmap docs + ESLint worktree ignore

### DIFF
--- a/docs/STREAMER_VIEW.md
+++ b/docs/STREAMER_VIEW.md
@@ -148,5 +148,19 @@ Things to know before enabling:
 ## Planned (not yet built)
 
 - Hero-model pick recognition (the `modelSelectionMarker` events mark the hook).
-- Twitch extension letting viewers browse pool abilities themselves.
 - Caster-triggered short clips explaining broken/bugged abilities during the draft.
+- **Twitch extension** letting viewers browse pool abilities themselves (PGL-style video
+  overlay). Deliberately deferred until Streamer View is finalized and cleaned up: the
+  board state assembled here is already the complete data set an overlay needs, so the
+  extension is primarily a *transport swap* — instead of SSE to localhost, the same
+  versioned `StreamEnvelope` goes to a hosted EBS that relays it to viewers via Twitch
+  PubSub. Do not design a second data path for it.
+  Extension-specific work that does NOT exist yet:
+  - EBS (small Node service): Twitch JWT verification, `send-extension-message` relay.
+    Envelope must fit the 5KB / 1-msg-per-sec-per-channel PubSub limits.
+  - Streamer-side opt-in: Twitch OAuth pairing + a "broadcast" toggle that pushes
+    envelopes to the EBS alongside (not instead of) the local SSE feed.
+  - Stream-delay sync: timestamp each envelope; the frontend buffers against
+    `hlsLatencyBroadcaster` so viewers see the board matching their delayed video.
+  - Overlay alignment assumes a fullscreen 16:9 game scene; cropped/custom OBS scenes
+    need a calibration offset on the extension config page.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,6 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ['out/', 'dist/', 'node_modules/', 'scripts/'],
+    ignores: ['out/', 'dist/', 'node_modules/', 'scripts/', '.claude/'],
   },
 )


### PR DESCRIPTION
## Summary

Two small pieces of session hygiene:

- **docs**: expand the Streamer View "Planned" section with the Twitch extension roadmap — it's a transport swap of the existing versioned `StreamEnvelope` (EBS + Twitch PubSub relay), not a second data path, plus the extension-specific work that doesn't exist yet (JWT-verifying EBS, streamer opt-in, stream-delay sync, overlay calibration).
- **lint**: add `.claude/` to the flat-config ignores — `eslint .` was drowning in ~6300 errors from build output inside stale Claude worktrees under `.claude/worktrees/` (patterns like `out/` only match at the config root).

No version bump.

## Test plan

- `npm run lint`: 0 errors, only the 5 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
