### PR TITLE
docs: point website references at abilitydraftplus.com

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -94,7 +94,7 @@ maintenance spec — the authoritative map of what IS, not a build plan.
   The opt-in `aghsMarkersEnabled` setting only adds always-on overlay markers,
   resolved in scan-processor (payload-gated)
 - `resources/data/ability_tags.json` + `hero_meta.json` are GENERATED (community Tag
-  Lab on tiarinhino.com + ../ad_data_gather_script/build_ability_tags.py; the durable
+  Lab on abilitydraftplus.com + ../ad_data_gather_script/build_ability_tags.py; the durable
   source of truth is that repo's tag_overrides.json) — never hand-edit, and keep
   TAG_VOCABULARY (core/domain/ability-tags.ts) in lockstep with the script's VOCAB
 - Role weights in thresholds.ts carry their empirical rationale (expert-draft corpus +

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > series that was accidentally lost in the v2 rewrite and is restored in **2.1.0**.
 > Open the app, go to the **Dashboard**, and press **Check for Updates** to receive
 > 2.1.0; from then on, the app checks automatically again. This notice will also be
-> published on the [website](https://tiarinhino.com) after its upcoming rehaul.
+> published on the [website](https://abilitydraftplus.com) after its upcoming rehaul.
 
 AI-powered overlay for Dota 2's Ability Draft mode. Scans the draft board using machine learning, identifies all abilities in the pool, and displays real-time synergy recommendations directly on your game screen.
 

--- a/docs/ROLE_SUGGESTIONS.md
+++ b/docs/ROLE_SUGGESTIONS.md
@@ -17,7 +17,8 @@ Both JSON files are GENERATED — never hand-edit. Pipeline:
 mechanical → heuristics → Liquipedia CC source-lists → LLM judgment →
 `tag_overrides.json`, which is the durable source of truth). Community flow and
 the export/import loop: `../tiarinhino.com/TAGS-WORKFLOW.md` (Tag Lab is LIVE at
-tiarinhino.com/ability-tags.html with a Lambda/DynamoDB backend).
+abilitydraftplus.com/ability-tags.html with a Lambda/DynamoDB backend; the repo
+is still named tiarinhino.com — the old host 301-redirects there).
 
 ## Scoring stack (fixed layer order)
 


### PR DESCRIPTION
## Summary
Docs-only change: README, `.claude/CLAUDE.md` and `docs/ROLE_SUGGESTIONS.md` now reference `abilitydraftplus.com` instead of `tiarinhino.com`. No code change, no release needed.

## Do not merge yet
Merge together with Tiarin-Hino/tiarinhino.com#3 after `DOMAIN-MIGRATION.md` step 6 passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)